### PR TITLE
Updated the first person look controls to support tilt actions.

### DIFF
--- a/2ship2harkinian.arbeq.json
+++ b/2ship2harkinian.arbeq.json
@@ -1,0 +1,871 @@
+{
+    "CVars": {
+        "gCheats": {
+            "InfiniteConsumables": 1,
+            "InfiniteHealth": 1,
+            "InfiniteMagic": 1,
+            "InfiniteRupees": 1,
+            "MoonJumpOnL": 0,
+            "NoClip": 0,
+            "UnbreakableRazorSword": 1,
+            "UnrestrictedItems": 1
+        },
+        "gDeveloperTools": {
+            "WarpPoint": {
+                "Entrance": 55296,
+                "Room": 0,
+                "Rotation": -4115.0,
+                "Saved": 1,
+                "X": -307.19012451171875,
+                "Y": 0.0,
+                "Z": -624.2359619140625
+            }
+        },
+        "gEnhancements": {
+            "Camera": {
+                "FirstPerson": {
+                    "GyroEnabled": 0,
+                    "GyroSensitivityX": 1.0,
+                    "GyroSensitivityY": 1.0,
+                    "RightStickEnabled": 1,
+                    "RightStickSensitivityX": 1.0
+                },
+                "FreeLook": {
+                    "Enable": 1,
+                    "MaxPitch": 72.0,
+                    "MinPitch": -49.0
+                }
+            },
+            "Cutscenes": {
+                "HideTitleCards": 1,
+                "SkipEntranceCutscenes": 1,
+                "SkipIntroSequence": 1,
+                "SkipMiscInteractions": 1,
+                "SkipStoryCutscenes": 1,
+                "SkipToFileSelect": 1
+            },
+            "Graphics": {
+                "BowReticle": 1
+            },
+            "Playback": {
+                "DpadOcarina": 1
+            },
+            "Saving": {
+                "PauseSave": 1
+            }
+        },
+        "gHudEditor": {
+            "CDown": {
+                "Mode": 3,
+                "Position": {
+                    "X": 72,
+                    "Y": 0
+                }
+            }
+        },
+        "gInterpolationFPS": 60,
+        "gMatchRefreshRate": 0,
+        "gOpenWindows": {
+            "ControllerConfiguration": 1
+        },
+        "gSettings": {
+            "Controllers": {
+                "AxisDirectionMappings": {
+                    "P0-S0-D0-LUSI0-SDLA0-ADN": {
+                        "AxisDirection": -1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 0,
+                        "SDLControllerAxis": 0,
+                        "ShipDeviceIndex": 0,
+                        "Stick": 0
+                    },
+                    "P0-S0-D0-LUSI1-SDLA0-ADN": {
+                        "AxisDirection": -1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 0,
+                        "SDLControllerAxis": 0,
+                        "ShipDeviceIndex": 1,
+                        "Stick": 0
+                    },
+                    "P0-S0-D0-LUSI2-SDLA0-ADN": {
+                        "AxisDirection": -1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 0,
+                        "SDLControllerAxis": 0,
+                        "ShipDeviceIndex": 2,
+                        "Stick": 0
+                    },
+                    "P0-S0-D1-LUSI0-SDLA0-ADP": {
+                        "AxisDirection": 1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 1,
+                        "SDLControllerAxis": 0,
+                        "ShipDeviceIndex": 0,
+                        "Stick": 0
+                    },
+                    "P0-S0-D1-LUSI1-SDLA0-ADP": {
+                        "AxisDirection": 1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 1,
+                        "SDLControllerAxis": 0,
+                        "ShipDeviceIndex": 1,
+                        "Stick": 0
+                    },
+                    "P0-S0-D1-LUSI2-SDLA0-ADP": {
+                        "AxisDirection": 1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 1,
+                        "SDLControllerAxis": 0,
+                        "ShipDeviceIndex": 2,
+                        "Stick": 0
+                    },
+                    "P0-S0-D2-LUSI0-SDLA1-ADN": {
+                        "AxisDirection": -1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 2,
+                        "SDLControllerAxis": 1,
+                        "ShipDeviceIndex": 0,
+                        "Stick": 0
+                    },
+                    "P0-S0-D2-LUSI1-SDLA1-ADN": {
+                        "AxisDirection": -1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 2,
+                        "SDLControllerAxis": 1,
+                        "ShipDeviceIndex": 1,
+                        "Stick": 0
+                    },
+                    "P0-S0-D2-LUSI2-SDLA1-ADN": {
+                        "AxisDirection": -1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 2,
+                        "SDLControllerAxis": 1,
+                        "ShipDeviceIndex": 2,
+                        "Stick": 0
+                    },
+                    "P0-S0-D3-LUSI0-SDLA1-ADP": {
+                        "AxisDirection": 1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 3,
+                        "SDLControllerAxis": 1,
+                        "ShipDeviceIndex": 0,
+                        "Stick": 0
+                    },
+                    "P0-S0-D3-LUSI1-SDLA1-ADP": {
+                        "AxisDirection": 1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 3,
+                        "SDLControllerAxis": 1,
+                        "ShipDeviceIndex": 1,
+                        "Stick": 0
+                    },
+                    "P0-S0-D3-LUSI2-SDLA1-ADP": {
+                        "AxisDirection": 1,
+                        "AxisDirectionMappingClass": "SDLAxisDirectionToAxisDirectionMapping",
+                        "Direction": 3,
+                        "SDLControllerAxis": 1,
+                        "ShipDeviceIndex": 2,
+                        "Stick": 0
+                    }
+                },
+                "ButtonMappings": {
+                    "P0-B0-KB20": {
+                        "SpecialButtonId": 3
+                    },
+                    "P0-B0-KB33": {
+                        "SpecialButtonId": 1
+                    },
+                    "P0-B0-KB36": {
+                        "SpecialButtonId": 1
+                    },
+                    "P0-B0-KB57": {
+                        "SpecialButtonId": 2
+                    },
+                    "P0-B0-LUSI0-SDLA1-ADP": {
+                        "AxisDirection": 1,
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 1,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B0-LUSI0-SDLB0": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 0,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B0-LUSI0-SDLB1": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 1,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B0-LUSI0-SDLB5": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 5,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B0-S1-LUSI0-SDLB0": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 0,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 1
+                    },
+                    "P0-B0-S1-LUSI0-SDLB1": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 1,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B0-S1-LUSI0-SDLB3": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 3,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B0-S1-LUSI0-SDLB5": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 5,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B0-S1-LUSI1-SDLB0": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 0,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 1
+                    },
+                    "P0-B0-S1-LUSI2-SDLB0": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 0,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 1
+                    },
+                    "P0-B0-S2-LUSI0-SDLB0": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 0,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 2
+                    },
+                    "P0-B0-S2-LUSI0-SDLB5": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 5,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B0-S2-LUSI0-SDLB8": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 8,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B0-S2-LUSI1-SDLB-1": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": -1,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 2
+                    },
+                    "P0-B0-S2-LUSI2-SDLB0": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 0,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 2
+                    },
+                    "P0-B0-S3-LUSI0-SDLB8": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 8,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 3
+                    },
+                    "P0-B0-S3-LUSI1-SDLB17": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 17,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 3
+                    },
+                    "P0-B0-S3-LUSI2-SDLB8": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 8,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 3
+                    },
+                    "P0-B0-S4-LUSI1-SDLB-1": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": -1,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 4
+                    },
+                    "P0-B0-S4-LUSI2-SDLB-1": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": -1,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 4
+                    },
+                    "P0-B0-S5-LUSI1-SDLB-1": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": -1,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 5
+                    },
+                    "P0-B0-S5-LUSI2-SDLB-1": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": -1,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 5
+                    },
+                    "P0-B0-S6-LUSI0-SDLB14": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 14,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 6
+                    },
+                    "P0-B0-S6-LUSI1-SDLB-1": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": -1,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 6
+                    },
+                    "P0-B0-S6-LUSI2-SDLB13": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 13,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 6
+                    },
+                    "P0-B0-S7-LUSI0-SDLB13": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 13,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 7
+                    },
+                    "P0-B0-S7-LUSI1-SDLB-1": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": -1,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 7
+                    },
+                    "P0-B0-S7-LUSI2-SDLB14": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 14,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 7
+                    },
+                    "P0-B0-S8-LUSI0-SDLB10": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 10,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 8
+                    },
+                    "P0-B0-S8-LUSI1-SDLB-1": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": -1,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 8
+                    },
+                    "P0-B0-S8-LUSI2-SDLB10": {
+                        "Bitmask": 0,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 10,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 8
+                    },
+                    "P0-B1-LUSI1-SDLA2-ADP": {
+                        "AxisDirection": 1,
+                        "Bitmask": 1,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 2,
+                        "ShipDeviceIndex": 1
+                    },
+                    "P0-B1-LUSI2-SDLA2-ADP": {
+                        "AxisDirection": 1,
+                        "Bitmask": 1,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 2,
+                        "ShipDeviceIndex": 2
+                    },
+                    "P0-B1-S0-LUSI0-SDLB3": {
+                        "Bitmask": 1,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 3,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B1024-S0-LUSI0-SDLB12": {
+                        "Bitmask": 1024,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 12,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B1024-S0-LUSI1-SDLB12": {
+                        "Bitmask": 1024,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 12,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B1024-S0-LUSI2-SDLB12": {
+                        "Bitmask": 1024,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 12,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B16-LUSI0-SDLA5-ADP": {
+                        "AxisDirection": 1,
+                        "Bitmask": 16,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 5,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B16-LUSI0-SDLB10": {
+                        "Bitmask": 16,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 10,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B16-LUSI1-SDLA5-ADP": {
+                        "AxisDirection": 1,
+                        "Bitmask": 16,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 5,
+                        "ShipDeviceIndex": 1
+                    },
+                    "P0-B16-LUSI2-SDLA5-ADP": {
+                        "AxisDirection": 1,
+                        "Bitmask": 16,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 5,
+                        "ShipDeviceIndex": 2
+                    },
+                    "P0-B16384-LUSI0-SDLB1": {
+                        "Bitmask": 16384,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 1,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B16384-S0-LUSI0-SDLB1": {
+                        "Bitmask": 16384,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 1,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B16384-S0-LUSI1-SDLB1": {
+                        "Bitmask": 16384,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 1,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B16384-S0-LUSI2-SDLB1": {
+                        "Bitmask": 16384,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 1,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B2-LUSI1-SDLA2-ADN": {
+                        "AxisDirection": -1,
+                        "Bitmask": 2,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 2,
+                        "ShipDeviceIndex": 1
+                    },
+                    "P0-B2-LUSI2-SDLA2-ADN": {
+                        "AxisDirection": -1,
+                        "Bitmask": 2,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 2,
+                        "ShipDeviceIndex": 2
+                    },
+                    "P0-B2-S0-LUSI0-SDLB9": {
+                        "Bitmask": 2,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 9,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B2048-S0-LUSI0-SDLB11": {
+                        "Bitmask": 2048,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 11,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B2048-S0-LUSI1-SDLB11": {
+                        "Bitmask": 2048,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 11,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B2048-S0-LUSI2-SDLB11": {
+                        "Bitmask": 2048,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 11,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B256-S0-LUSI0-SDLB14": {
+                        "Bitmask": 256,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 14,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B256-S0-LUSI1-SDLB14": {
+                        "Bitmask": 256,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 14,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B256-S0-LUSI2-SDLB14": {
+                        "Bitmask": 256,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 14,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B32-LUSI0-SDLB9": {
+                        "Bitmask": 32,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 9,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B32-S0-LUSI0-SDLB9": {
+                        "Bitmask": 32,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 9,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B32-S0-LUSI1-SDLB9": {
+                        "Bitmask": 32,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 9,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B32-S0-LUSI2-SDLB9": {
+                        "Bitmask": 32,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 9,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B32768-KB20": {
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B32768-LUSI0-SDLB0": {
+                        "Bitmask": 32768,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 0,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B32768-S0-LUSI0-SDLB0": {
+                        "Bitmask": 32768,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 0,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B32768-S0-LUSI1-SDLB0": {
+                        "Bitmask": 32768,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 0,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B32768-S0-LUSI2-SDLB0": {
+                        "Bitmask": 32768,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 0,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B4-LUSI1-SDLA3-ADP": {
+                        "AxisDirection": 1,
+                        "Bitmask": 4,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 3,
+                        "ShipDeviceIndex": 1
+                    },
+                    "P0-B4-LUSI2-SDLA3-ADP": {
+                        "AxisDirection": 1,
+                        "Bitmask": 4,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 3,
+                        "ShipDeviceIndex": 2
+                    },
+                    "P0-B4-S0-LUSI0-SDLB2": {
+                        "Bitmask": 4,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 2,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B4096-KB28": {
+                        "Bitmask": 4096,
+                        "ButtonMappingClass": "KeyboardKeyToButtonMapping",
+                        "KeyboardScancode": 28,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B4096-KB57": {
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B4096-LUSI0-SDLB6": {
+                        "Bitmask": 4096,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 6,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B4096-S0-LUSI0-SDLB6": {
+                        "Bitmask": 4096,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 6,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B4096-S0-LUSI1-SDLB6": {
+                        "Bitmask": 4096,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 6,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B4096-S0-LUSI2-SDLB6": {
+                        "Bitmask": 4096,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 6,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B512-S0-LUSI0-SDLB13": {
+                        "Bitmask": 512,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 13,
+                        "ShipDeviceIndex": 0,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B512-S0-LUSI1-SDLB13": {
+                        "Bitmask": 512,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 13,
+                        "ShipDeviceIndex": 1,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B512-S0-LUSI2-SDLB13": {
+                        "Bitmask": 512,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 13,
+                        "ShipDeviceIndex": 2,
+                        "SpecialButtonId": 0
+                    },
+                    "P0-B8-LUSI1-SDLA3-ADN": {
+                        "AxisDirection": -1,
+                        "Bitmask": 8,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 3,
+                        "ShipDeviceIndex": 1
+                    },
+                    "P0-B8-LUSI2-SDLA3-ADN": {
+                        "AxisDirection": -1,
+                        "Bitmask": 8,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 3,
+                        "ShipDeviceIndex": 2
+                    },
+                    "P0-B8-S0-LUSI0-SDLB5": {
+                        "Bitmask": 8,
+                        "ButtonMappingClass": "SDLButtonToButtonMapping",
+                        "SDLControllerButton": 5,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B8192-LUSI0-SDLA4-ADP": {
+                        "AxisDirection": 1,
+                        "Bitmask": 8192,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 4,
+                        "ShipDeviceIndex": 0
+                    },
+                    "P0-B8192-LUSI1-SDLA4-ADP": {
+                        "AxisDirection": 1,
+                        "Bitmask": 8192,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 4,
+                        "ShipDeviceIndex": 1
+                    },
+                    "P0-B8192-LUSI2-SDLA4-ADP": {
+                        "AxisDirection": 1,
+                        "Bitmask": 8192,
+                        "ButtonMappingClass": "SDLAxisDirectionToButtonMapping",
+                        "SDLControllerAxis": 4,
+                        "ShipDeviceIndex": 2
+                    }
+                },
+                "DeviceMappingIds": "Blue,Orange,Red,",
+                "DeviceMappings": {
+                    "Blue": {
+                        "DeviceMappingClass": "ShipDeviceIndexToSDLDeviceIndexMapping",
+                        "SDLControllerName": "Logitech Cordless RumblePad 2",
+                        "SDLDeviceIndex": 0,
+                        "SDLJoystickGUID": "05005d8eac0500000400000065706d04",
+                        "ShipDeviceIndex": 0,
+                        "StickAxisThresholdPercentage": 25,
+                        "TriggerAxisThresholdPercentage": 25
+                    },
+                    "Orange": {
+                        "DeviceMappingClass": "ShipDeviceIndexToSDLDeviceIndexMapping",
+                        "SDLControllerName": "Nintendo Switch Joy-Con (L/R)",
+                        "SDLDeviceIndex": 0,
+                        "SDLJoystickGUID": "0300460f7e0500000820000000006800",
+                        "ShipDeviceIndex": 2,
+                        "StickAxisThresholdPercentage": 25,
+                        "TriggerAxisThresholdPercentage": 25
+                    },
+                    "Red": {
+                        "DeviceMappingClass": "ShipDeviceIndexToSDLDeviceIndexMapping",
+                        "SDLControllerName": "Nintendo Switch Joy-Con (L)",
+                        "SDLDeviceIndex": 0,
+                        "SDLJoystickGUID": "030067007e0500000620000001006801",
+                        "ShipDeviceIndex": 1,
+                        "StickAxisThresholdPercentage": 25,
+                        "TriggerAxisThresholdPercentage": 25
+                    }
+                },
+                "GyroMappings": {
+                    "P0-LUSI2": {
+                        "GyroMappingClass": "SDLGyroMapping",
+                        "NeutralPitch": 0.0,
+                        "NeutralRoll": 0.0,
+                        "NeutralYaw": 0.0,
+                        "Sensitivity": 1.0,
+                        "ShipDeviceIndex": 2
+                    }
+                },
+                "Port1": {
+                    "Buttons": {
+                        "0ButtonMappingIds": "P0-B0-S3-LUSI0-SDLB8,",
+                        "1SpecialButtonMappingIds": "P0-B0-S1-LUSI0-SDLB0,",
+                        "2SpecialButtonMappingIds": "P0-B0-S2-LUSI0-SDLB2,",
+                        "3SpecialButtonMappingIds": "P0-B0-S3-LUSI0-SDLB8,",
+                        "AButtonMappingIds": "P0-B32768-S0-LUSI2-SDLB0,P0-B32768-S0-LUSI0-SDLB0,P0-B32768-S0-LUSI1-SDLB0,",
+                        "BButtonMappingIds": "P0-B16384-S0-LUSI2-SDLB1,P0-B16384-S0-LUSI0-SDLB1,P0-B16384-S0-LUSI1-SDLB1,",
+                        "CDownButtonMappingIds": "P0-B4-LUSI2-SDLA3-ADP,P0-B4-S0-LUSI0-SDLB2,P0-B4-LUSI1-SDLA3-ADP,",
+                        "CLeftButtonMappingIds": "P0-B2-LUSI2-SDLA2-ADN,P0-B2-S0-LUSI0-SDLB9,P0-B2-LUSI1-SDLA2-ADN,",
+                        "CRightButtonMappingIds": "P0-B1-LUSI2-SDLA2-ADP,P0-B1-S0-LUSI0-SDLB3,P0-B1-LUSI1-SDLA2-ADP,",
+                        "CUpButtonMappingIds": "P0-B8-LUSI2-SDLA3-ADN,P0-B8-LUSI1-SDLA3-ADN,",
+                        "DDownButtonMappingIds": "P0-B1024-S0-LUSI2-SDLB12,P0-B1024-S0-LUSI0-SDLB12,P0-B1024-S0-LUSI1-SDLB12,",
+                        "DLeftButtonMappingIds": "P0-B512-S0-LUSI2-SDLB13,P0-B512-S0-LUSI0-SDLB13,P0-B512-S0-LUSI1-SDLB13,",
+                        "DRightButtonMappingIds": "P0-B256-S0-LUSI0-SDLB14,P0-B256-S0-LUSI2-SDLB14,P0-B256-S0-LUSI1-SDLB14,",
+                        "DUpButtonMappingIds": "P0-B2048-S0-LUSI2-SDLB11,P0-B2048-S0-LUSI0-SDLB11,P0-B2048-S0-LUSI1-SDLB11,",
+                        "Draw BowButtonMappingIds": "P0-B0-S4-LUSI0-SDLB7,",
+                        "Fire BowButtonMappingIds": "P0-B0-S4-LUSI2-SDLB-1,",
+                        "Fire HookshotButtonMappingIds": "P0-B0-S5-LUSI2-SDLB-1,",
+                        "JumpButtonMappingIds": "P0-B0-S2-LUSI2-SDLB0,P0-B0-S2-LUSI0-SDLB0,",
+                        "LButtonMappingIds": "P0-B32-S0-LUSI2-SDLB9,P0-B32-S0-LUSI0-SDLB9,P0-B32-S0-LUSI1-SDLB9,",
+                        "RButtonMappingIds": "P0-B16-LUSI2-SDLA5-ADP,P0-B16-LUSI0-SDLA5-ADP,P0-B16-LUSI1-SDLA5-ADP,",
+                        "Release BowButtonMappingIds": "P0-B0-S5-LUSI0-SDLB8,",
+                        "RollButtonMappingIds": "P0-B0-S1-LUSI0-SDLB0,P0-B0-S1-LUSI2-SDLB0,P0-B0-S1-LUSI1-SDLB0,",
+                        "StartButtonMappingIds": "P0-B4096-S0-LUSI0-SDLB6,P0-B4096-KB28,P0-B4096-S0-LUSI2-SDLB6,P0-B4096-S0-LUSI1-SDLB6,",
+                        "Swap Item LeftButtonMappingIds": "P0-B0-S7-LUSI2-SDLB14,P0-B0-S7-LUSI0-SDLB13,",
+                        "Swap Item RightButtonMappingIds": "P0-B0-S6-LUSI2-SDLB13,P0-B0-S6-LUSI0-SDLB14,",
+                        "TalkButtonMappingIds": "P0-B0-S3-LUSI0-SDLB8,P0-B0-S3-LUSI2-SDLB8,P0-B0-S3-LUSI1-SDLB17,",
+                        "Use ItemButtonMappingIds": "P0-B0-S8-LUSI2-SDLB10,P0-B0-S8-LUSI0-SDLB10,",
+                        "ZButtonMappingIds": "P0-B8192-LUSI2-SDLA4-ADP,P0-B8192-LUSI0-SDLA4-ADP,P0-B8192-LUSI1-SDLA4-ADP,"
+                    },
+                    "Gyro": {
+                        "GyroMappingId": "P0-LUSI2"
+                    },
+                    "HasConfig": 1,
+                    "LEDMappingIds": "",
+                    "LeftStick": {
+                        "DeadzonePercentage": 20,
+                        "DownAxisDirectionMappingIds": "P0-S0-D3-LUSI0-SDLA1-ADP,P0-S0-D3-LUSI1-SDLA1-ADP,P0-S0-D3-LUSI2-SDLA1-ADP,",
+                        "LeftAxisDirectionMappingIds": "P0-S0-D0-LUSI0-SDLA0-ADN,P0-S0-D0-LUSI1-SDLA0-ADN,P0-S0-D0-LUSI2-SDLA0-ADN,",
+                        "NotchSnapAngle": 0,
+                        "RightAxisDirectionMappingIds": "P0-S0-D1-LUSI0-SDLA0-ADP,P0-S0-D1-LUSI1-SDLA0-ADP,P0-S0-D1-LUSI2-SDLA0-ADP,",
+                        "SensitivityPercentage": 100,
+                        "UpAxisDirectionMappingIds": "P0-S0-D2-LUSI0-SDLA1-ADN,P0-S0-D2-LUSI1-SDLA1-ADN,P0-S0-D2-LUSI2-SDLA1-ADN,"
+                    },
+                    "RightStick": {
+                        "DeadzonePercentage": 20,
+                        "DownAxisDirectionMappingIds": "P0-S1-D3-LUSI0-SDLA3-ADP,",
+                        "LeftAxisDirectionMappingIds": "P0-S1-D0-LUSI0-SDLA2-ADN,",
+                        "NotchSnapAngle": 0,
+                        "RightAxisDirectionMappingIds": "P0-S1-D1-LUSI0-SDLA2-ADP,",
+                        "SensitivityPercentage": 100,
+                        "UpAxisDirectionMappingIds": "P0-S1-D2-LUSI0-SDLA3-ADN,"
+                    },
+                    "RumbleMappingIds": "P0-LUSI2,P0-LUSI1,"
+                },
+                "Port2": {
+                    "HasConfig": 1,
+                    "LeftStick": {
+                        "DeadzonePercentage": 20,
+                        "NotchSnapAngle": 0,
+                        "SensitivityPercentage": 100
+                    },
+                    "RightStick": {
+                        "DeadzonePercentage": 20,
+                        "NotchSnapAngle": 0,
+                        "SensitivityPercentage": 100
+                    }
+                },
+                "RumbleMappings": {
+                    "P0-LUSI1": {
+                        "HighFrequencyIntensity": 100,
+                        "LowFrequencyIntensity": 100,
+                        "RumbleMappingClass": "SDLRumbleMapping",
+                        "ShipDeviceIndex": 1
+                    },
+                    "P0-LUSI2": {
+                        "HighFrequencyIntensity": 100,
+                        "LowFrequencyIntensity": 100,
+                        "RumbleMappingClass": "SDLRumbleMapping",
+                        "ShipDeviceIndex": 2
+                    }
+                }
+            },
+            "OpenMenuBar": 1,
+            "OverlayFont": "Press Start 2P"
+        }
+    },
+    "Window": {
+        "AudioBackend": "sdl",
+        "Backend": {
+            "Id": 4,
+            "Name": "Metal"
+        },
+        "Fullscreen": {
+            "Enabled": false
+        },
+        "Height": 1524,
+        "PositionX": 0,
+        "PositionY": 53,
+        "Width": 2880
+    }
+}

--- a/errors.txt
+++ b/errors.txt
@@ -1,0 +1,150 @@
+[1/3] Creating OSX icons ...
+/Users/christopher/GIT/2ship2harkinian/mm/macosx/2s2hIcon.png
+  /Users/christopher/GIT/2ship2harkinian/build-cmake/macosx/2s2h.iconset/icon_16x16.png
+/Users/christopher/GIT/2ship2harkinian/mm/macosx/2s2hIcon.png
+  /Users/christopher/GIT/2ship2harkinian/build-cmake/macosx/2s2h.iconset/icon_16x16@2x.png
+/Users/christopher/GIT/2ship2harkinian/mm/macosx/2s2hIcon.png
+  /Users/christopher/GIT/2ship2harkinian/build-cmake/macosx/2s2h.iconset/icon_32x32.png
+/Users/christopher/GIT/2ship2harkinian/mm/macosx/2s2hIcon.png
+  /Users/christopher/GIT/2ship2harkinian/build-cmake/macosx/2s2h.iconset/icon_32x32@2x.png
+/Users/christopher/GIT/2ship2harkinian/mm/macosx/2s2hIcon.png
+  /Users/christopher/GIT/2ship2harkinian/build-cmake/macosx/2s2h.iconset/icon_128x128.png
+/Users/christopher/GIT/2ship2harkinian/mm/macosx/2s2hIcon.png
+  /Users/christopher/GIT/2ship2harkinian/build-cmake/macosx/2s2h.iconset/icon_128x128@2x.png
+/Users/christopher/GIT/2ship2harkinian/mm/macosx/2s2hIcon.png
+  /Users/christopher/GIT/2ship2harkinian/build-cmake/macosx/2s2h.iconset/icon_256x256.png
+/Users/christopher/GIT/2ship2harkinian/mm/macosx/2s2hIcon.png
+  /Users/christopher/GIT/2ship2harkinian/build-cmake/macosx/2s2h.iconset/icon_256x256@2x.png
+/Users/christopher/GIT/2ship2harkinian/mm/macosx/2s2hIcon.png
+  /Users/christopher/GIT/2ship2harkinian/build-cmake/macosx/2s2h.iconset/icon_512x512.png
+[2/3] Building C object mm/CMakeFiles/2ship.dir/src/overlays/actors/ovl_player_actor/z_player.c.o
+In file included from /Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:8:
+In file included from /Users/christopher/GIT/2ship2harkinian/mm/include/global.h:4:
+In file included from /Users/christopher/GIT/2ship2harkinian/mm/include/z64.h:14:
+In file included from /Users/christopher/GIT/2ship2harkinian/mm/include/ultra64.h:8:
+/Users/christopher/GIT/2ship2harkinian/mm/include/PR/guint.h:19:9: warning: 'ROUND' macro redefined [-Wmacro-redefined]
+#define ROUND(x) (s32)(((x) >= 0.0) ? ((x) + 0.5) : ((x) - 0.5))
+        ^
+/Users/christopher/GIT/2ship2harkinian/mm/../libultraship/include/libultraship/libultra/gu.h:10:9: note: previous definition is here
+#define ROUND(x) (s32)(((x) >= 0.0) ? ((x) + 0.5) : ((x)-0.5))
+        ^
+In file included from /Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:8:
+In file included from /Users/christopher/GIT/2ship2harkinian/mm/include/global.h:4:
+In file included from /Users/christopher/GIT/2ship2harkinian/mm/include/z64.h:14:
+In file included from /Users/christopher/GIT/2ship2harkinian/mm/include/ultra64.h:10:
+In file included from /Users/christopher/GIT/2ship2harkinian/mm/include/PR/os.h:4:
+In file included from /Users/christopher/GIT/2ship2harkinian/mm/include/PR/os_ai.h:4:
+/Users/christopher/GIT/2ship2harkinian/mm/../libultraship/include/libultraship/libultra/os.h:35:9: warning: 'CONT_TYPE_MASK' macro redefined [-Wmacro-redefined]
+#define CONT_TYPE_MASK 0x1f07
+        ^
+/Users/christopher/GIT/2ship2harkinian/mm/../libultraship/include/libultraship/libultra/controller.h:73:9: note: previous definition is here
+#define CONT_TYPE_MASK 0x1F07
+        ^
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:1849:55: warning: using floating point absolute value function 'fabsf' when argument is of integer type [-Wabsolute-value]
+        if (PlayerAnimation_OnFrame(&this->skelAnime, fabsf(ANIMSFX_GET_FRAME(data)))) {
+                                                      ^
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:1849:55: note: use function 'abs' instead
+        if (PlayerAnimation_OnFrame(&this->skelAnime, fabsf(ANIMSFX_GET_FRAME(data)))) {
+                                                      ^~~~~
+                                                      abs
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:1849:55: note: include the header <stdlib.h> or explicitly provide a declaration for 'abs'
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:3803:64: warning: implicit conversion from enumeration type 'EquipSlot' to different enumeration type 'DpadEquipSlot' [-Wenum-conversion]
+                item = Player_Dpad_GetItemOnButton(play, this, i);
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~             ^
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:3865:15: warning: comparison of distinct pointer types ('PlayerAnimationHeader *' and 'const char (*)[66]') [-Wcompare-distinct-pointer-types]
+    if ((anim == &gPlayerAnim_link_normal_fighter2free) && (this->currentShield == PLAYER_SHIELD_NONE)) {
+         ~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:4172:84: warning: pointer type mismatch ('const char (*)[55]' and 'const char (*)[60]') [-Wpointer-type-mismatch]
+                                     : ((this->transformation == PLAYER_FORM_DEKU) ? &gPlayerAnim_pn_tamahakidf
+                                                                                   ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:4587:14: warning: comparison of distinct pointer types ('PlayerAnimationHeader *' and 'const char (*)[60]') [-Wcompare-distinct-pointer-types]
+    if (anim == &gPlayerAnim_link_derth_rebirth) {
+        ~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:5464:26: warning: comparison of integers of different signs: 'PlayerMeleeWeaponAnimation' (aka 'enum PlayerMeleeWeaponAnimation') and 's8' (aka 'signed char') [-Wsign-compare]
+    if ((meleeWeaponAnim != this->meleeWeaponAnimation) || (this->unk_ADD >= 3)) {
+         ~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:7213:48: warning: pointer type mismatch ('const char (*)[67]' and 'const char (*)[58]') [-Wpointer-type-mismatch]
+                                      var_v1_2 ? &gPlayerAnim_link_normal_Fclimb_startB
+                                               ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:7692:47: warning: pointer type mismatch ('const char (*)[55]' and 'const char (*)[70]') [-Wpointer-type-mismatch]
+                                              ? &gPlayerAnim_pn_drinkstart
+                                              ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:8143:75: warning: pointer type mismatch ('const char (*)[49]' and 'const char (*)[66]') [-Wpointer-type-mismatch]
+                        anim = (this->transformation == PLAYER_FORM_DEKU) ? &gPlayerAnim_pn_gurd
+                                                                          ^ ~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:8161:50: warning: comparison of distinct pointer types ('PlayerAnimationHeader *' and 'const char (*)[49]') [-Wcompare-distinct-pointer-types]
+                                           (anim == &gPlayerAnim_pn_gurd) ? 0.0f : endFrame, endFrame, ANIMMODE_ONCE,
+                                            ~~~~ ^  ~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:8588:63: warning: pointer type mismatch ('const char (*)[62]' and 'const char (*)[67]') [-Wpointer-type-mismatch]
+                      (this->stateFlags1 & PLAYER_STATE1_800) ? &gPlayerAnim_link_swimer_swim_get
+                                                              ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:9191:47: warning: pointer type mismatch ('const char (*)[49]' and 'const char (*)[61]') [-Wpointer-type-mismatch]
+                                              ? &gPlayerAnim_pn_getB
+                                              ^ ~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:12257:70: warning: pointer type mismatch ('const char (*)[72]' and 'const char (*)[60]') [-Wpointer-type-mismatch]
+                                          : ((this->shockTimer != 0) ? &gPlayerAnim_link_normal_electric_shock_end
+                                                                     ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:12659:39: warning: incompatible pointer to integer conversion passing 'Gfx *' (aka 'union Gfx *') to parameter of type 'uintptr_t' (aka 'unsigned long') [-Wint-conversion]
+    gSPSegment(POLY_OPA_DISP++, 0x0C, cullDList);
+                                      ^~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/include/gfx.h:245:52: note: passing argument to parameter 'target' here
+void gSPSegment(void* value, int segNum, uintptr_t target);
+                                                   ^
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:12660:39: warning: incompatible pointer to integer conversion passing 'Gfx *' (aka 'union Gfx *') to parameter of type 'uintptr_t' (aka 'unsigned long') [-Wint-conversion]
+    gSPSegment(POLY_XLU_DISP++, 0x0C, cullDList);
+                                      ^~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/include/gfx.h:245:52: note: passing argument to parameter 'target' here
+void gSPSegment(void* value, int segNum, uintptr_t target);
+                                                   ^
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:12955:24: warning: incompatible pointer to integer conversion passing 'Gfx *' (aka 'union Gfx *') to parameter of type 'uintptr_t' (aka 'unsigned long') [-Wint-conversion]
+                       Gfx_TwoTexScroll(play->state.gfxCtx, 0, 0, -(s32)play->gameplayFrames & 0x7F, 0x20, 0x20, 1, 0,
+                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/include/gfx.h:245:52: note: passing argument to parameter 'target' here
+void gSPSegment(void* value, int segNum, uintptr_t target);
+                                                   ^
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:13000:29: warning: expected ';' at end of declaration list
+    typedef struct  {s16 x,y} Stick;
+                            ^
+                            ;
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:13348:72: warning: pointer type mismatch ('const char (*)[60]' and 'const char (*)[61]') [-Wpointer-type-mismatch]
+                                                 (this->mountSide < 0) ? &gPlayerAnim_link_uma_left_down
+                                                                       ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:13793:46: warning: pointer type mismatch ('const char (*)[55]' and 'const char (*)[65]') [-Wpointer-type-mismatch]
+                                             ? &gPlayerAnim_pn_tamahakidf
+                                             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:13814:81: warning: pointer type mismatch ('const char (*)[55]' and 'const char (*)[64]') [-Wpointer-type-mismatch]
+                                     (this->transformation == PLAYER_FORM_DEKU) ? &gPlayerAnim_pn_tamahakidf
+                                                                                ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:14868:42: warning: pointer type mismatch ('const char (*)[65]' and 'const char (*)[64]') [-Wpointer-type-mismatch]
+                                         ? &gPlayerAnim_link_normal_front_downB
+                                         ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:14892:69: warning: pointer type mismatch ('const char (*)[69]' and 'const char (*)[68]') [-Wpointer-type-mismatch]
+                      (this->currentYaw != this->actor.shape.rot.y) ? &gPlayerAnim_link_normal_front_down_wake
+                                                                    ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:16036:61: warning: pointer type mismatch ('const char (*)[63]' and 'PlayerAnimationHeader *') [-Wpointer-type-mismatch]
+                                 (this->av1.actionVar1 > 0) ? &gPlayerAnim_link_normal_fall_wait
+                                                            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:17366:78: warning: pointer type mismatch ('const char (*)[49]' and 'const char (*)[61]') [-Wpointer-type-mismatch]
+                                  (this->transformation == PLAYER_FORM_DEKU) ? &gPlayerAnim_pn_getB
+                                                                             ^ ~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:17370:78: warning: pointer type mismatch ('const char (*)[49]' and 'const char (*)[61]') [-Wpointer-type-mismatch]
+                                  (this->transformation == PLAYER_FORM_DEKU) ? &gPlayerAnim_pn_getA
+                                                                             ^ ~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:17497:70: warning: pointer type mismatch ('const char (*)[50]' and 'const char (*)[69]') [-Wpointer-type-mismatch]
+                          (this->transformation == PLAYER_FORM_DEKU) ? &gPlayerAnim_pn_drink
+                                                                     ^ ~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:17698:24: warning: implicit conversion from 'int' to 's16' (aka 'short') changes value from 32768 to -32768 [-Wconstant-conversion]
+        { ACTOR_EN_OT, SEAHORSE_PARAMS(SEAHORSE_TYPE_2, 0, 0) },                         // PLAYER_BOTTLE_SEAHORSE
+        ~              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_En_Ot/z_en_ot.h:14:107: note: expanded from macro 'SEAHORSE_PARAMS'
+#define SEAHORSE_PARAMS(type, pathIndex, switchFlag) (((pathIndex) & 0x7F) | (((switchFlag) & 0x7F) << 7) | (((type) & 3) << 0xE))
+                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:18151:34: warning: comparison of distinct pointer types ('PlayerAnimationHeader *' and 'const char (*)[75]') [-Wcompare-distinct-pointer-types]
+                } else if ((anim == &gPlayerAnim_link_fighter_Lpower_jump_kiru_end) &&
+                            ~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/Users/christopher/GIT/2ship2harkinian/mm/src/overlays/actors/ovl_player_actor/z_player.c:20213:62: warning: pointer type mismatch ('const char (*)[49]' and 'const char (*)[61]') [-Wpointer-type-mismatch]
+                  (this->transformation == PLAYER_FORM_DEKU) ? &gPlayerAnim_pn_getA : &gPlayerAnim_link_demo_get_itemA);
+                                                             ^ ~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+31 warnings generated.
+[3/3] Linking CXX executable mm/2s2h-macos
+ld: warning: ignoring duplicate libraries: 'libultraship/src/libultraship.a'

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -339,6 +339,46 @@ void DrawEnhancementsMenu() {
                 { .tooltip =
                       "Fixes the camera snap that occurs when you are moving and press the targetting button." });
 
+            ImGui::SeparatorText("First Person");
+            UIWidgets::CVarCheckbox("Invert X Axis", "gEnhancements.Camera.FirstPerson.InvertX");
+            UIWidgets::CVarCheckbox("Invert Y Axis", "gEnhancements.Camera.FirstPerson.InvertY",
+                                    { .defaultValue = true });
+            UIWidgets::CVarSliderFloat("X Axis Sensitivity: %.0f%%", "gEnhancements.Camera.FirstPerson.SensitivityX",
+                                       0.1f, 2.0f, 1.0f, { .isPercentage = true });
+            UIWidgets::CVarSliderFloat("Y Axis Sensitivity: %.0f%%", "gEnhancements.Camera.FirstPerson.SensitivityY",
+                                       0.1f, 2.0f, 1.0f, { .isPercentage = true });
+            UIWidgets::CVarCheckbox(
+                "Gyro Aiming", "gEnhancements.Camera.FirstPerson.GyroEnabled",
+                { .tooltip = "Enables gyro aiming in first person mode. Requires a controller with gyro support, and "
+                             "for it to be mapped in the Controller Mapping menu" });
+            if (CVarGetInteger("gEnhancements.Camera.FirstPerson.GyroEnabled", 0)) {
+                UIWidgets::CVarCheckbox("Invert Gyro X Axis", "gEnhancements.Camera.FirstPerson.GyroInvertX");
+                UIWidgets::CVarCheckbox("Invert Gyro Y Axis", "gEnhancements.Camera.FirstPerson.GyroInvertY");
+                UIWidgets::CVarSliderFloat("Gyro X Axis Sensitivity: %.0f%%",
+                                           "gEnhancements.Camera.FirstPerson.GyroSensitivityX", 0.1f, 2.0f, 1.0f,
+                                           { .isPercentage = true });
+                UIWidgets::CVarSliderFloat("Gyro Y Axis Sensitivity: %.0f%%",
+                                           "gEnhancements.Camera.FirstPerson.GyroSensitivityY", 0.1f, 2.0f, 1.0f,
+                                           { .isPercentage = true });
+            }
+
+            UIWidgets::CVarCheckbox(
+                "Right Stick Aiming", "gEnhancements.Camera.FirstPerson.RightStickEnabled",
+                { .tooltip = "Enables right stick aiming in first person mode. Requires the controller right stick to "
+                             "be mapped in the Controller Mapping menu" });
+            if (CVarGetInteger("gEnhancements.Camera.FirstPerson.RightStickEnabled", 0)) {
+                UIWidgets::CVarCheckbox("Invert Right Stick X Axis",
+                                        "gEnhancements.Camera.FirstPerson.RightStickInvertX");
+                UIWidgets::CVarCheckbox("Invert Right Stick Y Axis",
+                                        "gEnhancements.Camera.FirstPerson.RightStickInvertY", { .defaultValue = true });
+                UIWidgets::CVarSliderFloat("Right Stick X Axis Sensitivity: %.0f%%",
+                                           "gEnhancements.Camera.FirstPerson.RightStickSensitivityX", 0.1f, 2.0f, 1.0f,
+                                           { .isPercentage = true });
+                UIWidgets::CVarSliderFloat("Right Stick Y Axis Sensitivity: %.0f%%",
+                                           "gEnhancements.Camera.FirstPerson.RightStickSensitivityY", 0.1f, 2.0f, 1.0f,
+                                           { .isPercentage = true });
+            }
+
             ImGui::SeparatorText("Free Look");
             if (UIWidgets::CVarCheckbox(
                     "Free Look", "gEnhancements.Camera.FreeLook.Enable",

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
@@ -213,6 +213,16 @@ int GameInteractor_InvertControl(GIInvertType type) {
                 result *= -1;
             }
             break;
+        case GI_INVERT_FIRST_PERSON_AIM_X:
+            if (CVarGetInteger("gEnhancements.Camera.FirstPerson.InvertX", 0)) {
+                result *= -1;
+            }
+            break;
+        case GI_INVERT_FIRST_PERSON_AIM_Y:
+            if (CVarGetInteger("gEnhancements.Camera.FirstPerson.InvertY", 1)) {
+                result *= -1;
+            }
+            break;
     }
 
     /*
@@ -220,6 +230,7 @@ int GameInteractor_InvertControl(GIInvertType type) {
     if (CVarGetInteger("gModes.MirroredWorld.State", 0)) {
         switch (type) {
             case GI_INVERT_CAMERA_RIGHT_STICK_X:
+            case GI_INVERT_FIRST_PERSON_AIM_X:
                 result *= -1;
                 break;
         }

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
@@ -57,6 +57,8 @@ typedef enum {
 typedef enum {
     GI_INVERT_CAMERA_RIGHT_STICK_X,
     GI_INVERT_CAMERA_RIGHT_STICK_Y,
+    GI_INVERT_FIRST_PERSON_AIM_X,
+    GI_INVERT_FIRST_PERSON_AIM_Y,
 } GIInvertType;
 
 typedef enum {

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13036,14 +13036,16 @@ s32 Ship_HandleFirstPersonAiming(PlayState* play, Player* this, s32 arg2) {
         // TODO: Set the tiltOffset values and store static tilt states appropriate for the gyro controls.
         // Note: This doesn't necessarily have to constrain the tilt values to the range -1 to 1 for gyros.
 
-        // float currentTiltX = ??
-        // float currentTiltY = ??
+        float currentTiltX = sPlayerControlInput->cur.gyro_y;
+        float currentTiltY = sPlayerControlInput->cur.gyro_x;
 
-        // tiltOffsetX = currentTiltX - tiltX;
-        // tiltOffsetY = currentTiltY - tiltY;
+        tiltOffsetX = currentTiltX * 1400
+            * CVarGetFloat("gEnhancements.Camera.FirstPerson.GyroSensitivityX", 1.0f)
+            * (CVarGetInteger("gEnhancements.Camera.FirstPerson.GyroInvertX", 0) ? -1 : 1);
+        tiltOffsetY = currentTiltY * -800
+            * CVarGetFloat("gEnhancements.Camera.FirstPerson.GyroSensitivityY", 1.0f)
+            * (CVarGetInteger("gEnhancements.Camera.FirstPerson.GyroInvertY", 0) ? -1 : 1);
 
-        // tiltX = currentTiltX;
-        // tiltY = currentTiltY;
     }
     else
     {

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13028,27 +13028,26 @@ s32 Ship_HandleFirstPersonAiming(PlayState* play, Player* this, s32 arg2) {
     float tiltOffsetX = 0;
     float tiltOffsetY = 0;
 
-    // Static variables are needed to track the previous tilt amounts between invocations of this function.
-    static float tiltX = 0; // -1 to 1
-    static float tiltY = 0; // -1 to 1
 
     if (CVarGetInteger("gEnhancements.Camera.FirstPerson.GyroEnabled", 0)){
-        // TODO: Set the tiltOffset values and store static tilt states appropriate for the gyro controls.
-        // Note: This doesn't necessarily have to constrain the tilt values to the range -1 to 1 for gyros.
+        // Gyro tilts manage their own state and don't need static tracking variables.
 
         float currentTiltX = sPlayerControlInput->cur.gyro_y;
         float currentTiltY = sPlayerControlInput->cur.gyro_x;
 
+        // Scale the tilt amount and apply it.
         tiltOffsetX = currentTiltX * 1400
             * CVarGetFloat("gEnhancements.Camera.FirstPerson.GyroSensitivityX", 1.0f)
             * (CVarGetInteger("gEnhancements.Camera.FirstPerson.GyroInvertX", 0) ? -1 : 1);
         tiltOffsetY = currentTiltY * -800
             * CVarGetFloat("gEnhancements.Camera.FirstPerson.GyroSensitivityY", 1.0f)
             * (CVarGetInteger("gEnhancements.Camera.FirstPerson.GyroInvertY", 0) ? -1 : 1);
-
     }
     else
     {
+        // Static variables are needed to track the previous tilt amounts between invocations of this function.
+        static float tiltX = 0; // -1 to 1
+        static float tiltY = 0; // -1 to 1
         // The stick amounts range from -84 to 84, so here they are standardized into a -1 to 1 range.
         float currentTiltX = -(((float) tiltStick->x) / 84.0); // -1 to 1
         float currentTiltY = -(((float) tiltStick->y) / 84.0); // -1 to 1
@@ -13094,7 +13093,7 @@ s32 Ship_HandleFirstPersonAiming(PlayState* play, Player* this, s32 arg2) {
         this->actor.focus.rot.y = CLAMP(var_s0, -0x4AAA, 0x4AAA) + this->actor.shape.rot.y;
     }
 
-    // Add the tilt offsets to the rotation tweak the camera direction separately from the regular movement.
+    // Add the tilt offsets to the rotation without applying smoothing.
     this->actor.focus.rot.x += tiltOffsetY;
     this->actor.focus.rot.y += tiltOffsetX;
 

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12993,7 +12993,78 @@ void Player_Destroy(Actor* thisx, PlayState* play) {
     func_80831454(this);
 }
 
+s32 Ship_HandleFirstPersonAiming(PlayState* play, Player* this, s32 arg2) {
+    s16 var_s0;
+    s32 stickX = sPlayerControlInput->rel.stick_x; // -60 to 60
+    s32 stickY = sPlayerControlInput->rel.stick_y; // -60 to 60
+
+    stickX *= GameInteractor_InvertControl(GI_INVERT_FIRST_PERSON_AIM_X);
+    stickY *= -GameInteractor_InvertControl(GI_INVERT_FIRST_PERSON_AIM_Y);
+
+    stickX *= CVarGetFloat("gEnhancements.Camera.FirstPerson.SensitivityX", 1.0f);
+    stickY *= CVarGetFloat("gEnhancements.Camera.FirstPerson.SensitivityY", 1.0f);
+
+    if (CVarGetInteger("gEnhancements.Camera.FirstPerson.GyroEnabled", 0)) {
+        float gyroX = -sPlayerControlInput->cur.gyro_y; // -40 to 40, avg -4 to 4
+        float gyroY = sPlayerControlInput->cur.gyro_x;  // -20 to 20, avg -2 to 2
+
+        gyroX *= CVarGetInteger("gEnhancements.Camera.FirstPerson.GyroInvertX", 0) ? 1 : -1;
+        gyroY *= CVarGetInteger("gEnhancements.Camera.FirstPerson.GyroInvertY", 0) ? 1 : -1;
+
+        stickX += gyroX * 60.0f * CVarGetFloat("gEnhancements.Camera.FirstPerson.GyroSensitivityX", 1.0f);
+        stickY += gyroY * 60.0f * CVarGetFloat("gEnhancements.Camera.FirstPerson.GyroSensitivityY", 1.0f);
+    }
+
+    if (CVarGetInteger("gEnhancements.Camera.FirstPerson.RightStickEnabled", 0)) {
+        s32 rightStickX = sPlayerControlInput->cur.right_stick_x; // -40 to 40, avg -4 to 4
+        s32 rightStickY = sPlayerControlInput->cur.right_stick_y; // -20 to 20, avg -2 to 2
+
+        rightStickX *= -(CVarGetInteger("gEnhancements.Camera.FirstPerson.RightStickInvertX", 0) ? 1 : -1);
+        rightStickY *= (CVarGetInteger("gEnhancements.Camera.FirstPerson.RightStickInvertY", 1) ? 1 : -1);
+
+        stickX += rightStickX * CVarGetFloat("gEnhancements.Camera.FirstPerson.RightStickSensitivityX", 1.0f);
+        stickY += rightStickY * CVarGetFloat("gEnhancements.Camera.FirstPerson.RightStickSensitivityY", 1.0f);
+    }
+
+    stickX = CLAMP(stickX, -60, 60);
+    stickY = CLAMP(stickY, -60, 60);
+
+    if (!func_800B7128(this) && !func_8082EF20(this) && !arg2) { // First person without weapon
+        var_s0 = stickY * 0xF0;
+        Math_SmoothStepToS(&this->actor.focus.rot.x, var_s0, 0xE, 0xFA0, 0x1E);
+
+        var_s0 = stickX * -0x10;
+        var_s0 = CLAMP(var_s0, -0xBB8, 0xBB8);
+        this->actor.focus.rot.y += var_s0;
+    } else { // First person with weapon
+        s16 temp3;
+
+        temp3 = ((stickY >= 0) ? 1 : -1) * (s32)((1.0f - Math_CosS(stickY * 0xC8)) * 1500.0f);
+        this->actor.focus.rot.x += temp3;
+
+        if (this->stateFlags1 & PLAYER_STATE1_800000) {
+            this->actor.focus.rot.x = CLAMP(this->actor.focus.rot.x, -0x1F40, 0xFA0);
+        } else {
+            this->actor.focus.rot.x = CLAMP(this->actor.focus.rot.x, -0x36B0, 0x36B0);
+        }
+
+        var_s0 = this->actor.focus.rot.y - this->actor.shape.rot.y;
+        temp3 = ((stickX >= 0) ? 1 : -1) * (s32)((1.0f - Math_CosS(stickX * 0xC8)) * -1500.0f);
+        var_s0 += temp3;
+
+        this->actor.focus.rot.y = CLAMP(var_s0, -0x4AAA, 0x4AAA) + this->actor.shape.rot.y;
+    }
+
+    this->unk_AA6 |= 2;
+
+    return func_80832754(this, (play->bButtonAmmoPlusOne != 0) || func_800B7128(this) || func_8082EF20(this));
+}
+
 s32 func_80847190(PlayState* play, Player* this, s32 arg2) {
+    // #region 2S2H [Enhancements] Use our own heavily modified version of this for customizations
+    return Ship_HandleFirstPersonAiming(play, this, arg2);
+    // #endregion
+
     s32 pad;
     s16 var_s0;
 


### PR DESCRIPTION
This PR adds logic for a separate "Tilt" control for first person view.
Tilting the camera does not continuously move the camera, and also isn't permanent.

The gyro controls are disabled with this change, as I do not have a gyro device to test it properly.
The basic logic exists though, so a developer with access to a gyro device should be able to plug-in the tilt logic for gyros.

This change also uses the "other" joystick to apply the tilt to the camera. The "RightStickEnabled" flag results in the 2 joysticks being swapped, and the "GyroEnabled" flag disables the joystick tilt.