### PR TITLE
Add Mayor's Office cutscene skip

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/Cutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/Cutscenes.cpp
@@ -8,6 +8,7 @@ void RegisterCutscenes() {
     RegisterSkipKafeiReveal();
     RegisterSkipScarecrowDance();
     RegisterSkipTatlInterrupts();
+    RegisterSkipMayorsOfficeCutscene();
 
     // StoryCutscenes
     RegisterSkipClockTowerOpen();

--- a/mm/2s2h/Enhancements/Cutscenes/Cutscenes.h
+++ b/mm/2s2h/Enhancements/Cutscenes/Cutscenes.h
@@ -10,6 +10,7 @@ void RegisterSkipGreatFairyCutscene();
 void RegisterSkipKafeiReveal();
 void RegisterSkipScarecrowDance();
 void RegisterSkipTatlInterrupts();
+void RegisterSkipMayorsOfficeCutscene();
 
 // StoryCutscenes
 void RegisterSkipClockTowerOpen();

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
@@ -1,0 +1,47 @@
+#include <libultraship/libultraship.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "overlays/actors/ovl_En_Dt/z_en_dt.h"
+void func_80BEA394(EnDt* enDt, PlayState* play);
+}
+
+void mayorSceneNoCouplesMask() {
+    if (CVarGetInteger("gEnhancements.Cutscenes.SkipMiscInteractions", 0)) {
+        EnDt* enDt =
+            (EnDt*)Actor_FindNearby(gPlayState, &GET_PLAYER(gPlayState)->actor, ACTOR_EN_DT, ACTORCAT_NPC, 99999.9f);
+        if (enDt != nullptr) {
+            enDt->actionFunc = func_80BEA394;
+            enDt->unk_26E = 26;
+            enDt->unk_270 = 2;
+            enDt->unk_256 = 8;
+        }
+    }
+}
+
+// These skips still allow the first textboxes to display, but they do ignore most of the scene
+void RegisterSkipMayorsOfficeCutscene() {
+    // "Most townsfolk have already taken shelter..." (no mask, first interaction)
+    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnOpenText>(
+        0x2ABD, [](u16* textId, bool* loadFromMessageTable) { mayorSceneNoCouplesMask(); });
+
+    // "All must take refuge!" (no mask, subsequent interactions)
+    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnOpenText>(
+        0x2ABB, [](u16* textId, bool* loadFromMessageTable) { mayorSceneNoCouplesMask(); });
+
+    // "Ah!" (wearing Couple's Mask)
+    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnOpenText>(
+        0x2AC6, [](u16* textId, bool* loadFromMessageTable) {
+            if (CVarGetInteger("gEnhancements.Cutscenes.SkipMiscInteractions", 0)) {
+                EnDt* enDt = (EnDt*)Actor_FindNearby(gPlayState, &GET_PLAYER(gPlayState)->actor, ACTOR_EN_DT,
+                                                     ACTORCAT_NPC, 99999.9f);
+                if (enDt != nullptr) {
+                    // Set flags to trigger scene transition and reward
+                    enDt->actionFunc = func_80BEA394;
+                    enDt->unk_244 = 0;
+                    enDt->unk_256 = 20;
+                    enDt->unk_270 = 0;
+                }
+            }
+        });
+}


### PR DESCRIPTION
This cutscene is weird in that it fires off a textbox the instant it is triggered, or maybe it's more accurate to say it's just a long NPC conversation with camera work. I tried approaching the skip several different ways, but none could skip the first textbox itself. Since I found no way around displaying that initial text, the `OnOpenText` hook provided a convenient way to avoid touching `mm/src` files entirely, not needing to check state information.

First textboxes aside, this skips all three variants of the Mayor's Office argument scene. For the Couple's Mask variant, it cuts to the scene transition where everybody has left, and the mayor bestows the reward as normal.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2108549666.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2108552915.zip)
<!--- section:artifacts:end -->