### PR TITLE
Fix bug with Bomb Shop Lady check handling

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnBaba.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnBaba.cpp
@@ -14,18 +14,21 @@ void EnBaba_GaveBlastMask(EnBaba* enBaba, PlayState* play);
 // this case, as Link can move freely once the next textbox appears. This code fixes that.
 void Rando::ActorBehavior::InitEnBabaBehavior() {
     COND_VB_SHOULD(VB_GIVE_ITEM_FROM_OFFER, IS_RANDO, {
-        *should = false;
-
         GetItemId* item = va_arg(args, GetItemId*);
-        EnBaba* enBaba = va_arg(args, EnBaba*);
-        Player* player = GET_PLAYER(gPlayState);
-        enBaba->stateFlags |= BOMB_SHOP_LADY_STATE_GAVE_BLAST_MASK;
-        enBaba->actionFunc = EnBaba_GaveBlastMask;
-        enBaba->actor.parent = &player->actor;
-        player->talkActor = &enBaba->actor;
-        player->talkActorDistance = enBaba->actor.xzDistToPlayer;
-        player->exchangeItemAction = PLAYER_IA_MINUS1;
-        Player_TalkWithPlayer(gPlayState, &enBaba->actor);
-        RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_NORTH_BOMB_LADY].eligible = true;
+        Actor* actor = va_arg(args, Actor*);
+        // This runs for all actors using Actor_OfferGetItem, so make sure we only do this with the Bomb Shop Lady.
+        if (actor->id == ACTOR_EN_BABA) {
+            *should = false;
+            EnBaba* enBaba = (EnBaba*)actor;
+            Player* player = GET_PLAYER(gPlayState);
+            enBaba->stateFlags |= BOMB_SHOP_LADY_STATE_GAVE_BLAST_MASK;
+            enBaba->actionFunc = EnBaba_GaveBlastMask;
+            enBaba->actor.parent = &player->actor;
+            player->talkActor = &enBaba->actor;
+            player->talkActorDistance = enBaba->actor.xzDistToPlayer;
+            player->exchangeItemAction = PLAYER_IA_MINUS1;
+            Player_TalkWithPlayer(gPlayState, &enBaba->actor);
+            RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_NORTH_BOMB_LADY].eligible = true;
+        }
     });
 }


### PR DESCRIPTION
`VB_GIVE_ITEM_FROM_OFFER` runs for *any* actor running `Actor_OfferGetItem`, which is used for more than just item offers (e.g. actors that can be picked up). `InitEnBabaBehavior` did not actually check the actor calling it, resulting in a bug where other actors could trap Link in an invalid conversation. This PR adds a check for the actor ID.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2135043667.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2135050557.zip)
<!--- section:artifacts:end -->