### PR TITLE
Handle first cycle time speed

### DIFF
--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -116,6 +116,7 @@ typedef enum {
     VB_QUEUE_CUTSCENE,
     VB_GIVE_ITEM_FROM_MNK,
     VB_TERMINA_FIELD_BE_EMPTY,
+    VB_FASTER_FIRST_CYCLE,
 } GIVanillaBehavior;
 
 typedef enum {

--- a/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
@@ -25,7 +25,10 @@ void Rando::MiscBehavior::OnFileLoad() {
     COND_VB_SHOULD(VB_TERMINA_FIELD_BE_EMPTY, IS_RANDO, { *should = false; });
 
     // Override "first-cycle" timespeed if you don't have the Ocarina
-    COND_HOOK(AfterRoomSceneCommands, IS_RANDO, [](s16 sceneId, s8 roomNum) { if (R_TIME_SPEED == 5) R_TIME_SPEED = 3; });
+    COND_HOOK(AfterRoomSceneCommands, IS_RANDO, [](s16 sceneId, s8 roomNum) {
+        if (R_TIME_SPEED == 5)
+            R_TIME_SPEED = 3;
+    });
 
     // In Sram_OpenSave (right before this code runs) for non-owl saves, it overwrites the entrance to
     // ENTRANCE(CUTSCENE, 0), we need to override that with our starting location (Harcoded to South Clock Town)

--- a/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
@@ -24,11 +24,8 @@ void Rando::MiscBehavior::OnFileLoad() {
     // This overrides the ocarina condition for Termina Field
     COND_VB_SHOULD(VB_TERMINA_FIELD_BE_EMPTY, IS_RANDO, { *should = false; });
 
-    // Override "first-cycle" timespeed if you don't have the Ocarina
-    COND_HOOK(AfterRoomSceneCommands, IS_RANDO, [](s16 sceneId, s8 roomNum) {
-        if (R_TIME_SPEED == 5)
-            R_TIME_SPEED = 3;
-    });
+    // Override faster first-cycle time speed if you don't have the Ocarina
+    COND_VB_SHOULD(VB_FASTER_FIRST_CYCLE, IS_RANDO, { *should = false; });
 
     // In Sram_OpenSave (right before this code runs) for non-owl saves, it overwrites the entrance to
     // ENTRANCE(CUTSCENE, 0), we need to override that with our starting location (Harcoded to South Clock Town)

--- a/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
@@ -24,6 +24,9 @@ void Rando::MiscBehavior::OnFileLoad() {
     // This overrides the ocarina condition for Termina Field
     COND_VB_SHOULD(VB_TERMINA_FIELD_BE_EMPTY, IS_RANDO, { *should = false; });
 
+    // Override "first-cycle" timespeed if you don't have the Ocarina
+    COND_HOOK(AfterRoomSceneCommands, IS_RANDO, [](s16 sceneId, s8 roomNum) { if (R_TIME_SPEED == 5) R_TIME_SPEED = 3; });
+
     // In Sram_OpenSave (right before this code runs) for non-owl saves, it overwrites the entrance to
     // ENTRANCE(CUTSCENE, 0), we need to override that with our starting location (Harcoded to South Clock Town)
     if (!gSaveContext.save.isOwlSave) {

--- a/mm/2s2h/z_scene_2SH.cpp
+++ b/mm/2s2h/z_scene_2SH.cpp
@@ -283,7 +283,9 @@ void Scene_CommandTimeSettings(PlayState* play, SOH::ISceneCommand* cmd) {
     }
 
     // Increase time speed during first cycle
-    if ((gSaveContext.save.saveInfo.inventory.items[SLOT_OCARINA] == ITEM_NONE) && (play->envCtx.sceneTimeSpeed != 0)) {
+    if (GameInteractor_Should(VB_FASTER_FIRST_CYCLE,
+                              (gSaveContext.save.saveInfo.inventory.items[SLOT_OCARINA] == ITEM_NONE) &&
+                                  (play->envCtx.sceneTimeSpeed != 0))) {
         play->envCtx.sceneTimeSpeed = 5;
     }
 


### PR DESCRIPTION
The faster first cycle time is based on having the Ocarina in your inventory. This will change the faster time speed to the normal time speed in Rando regardless of whether the Ocarina is obtained. 

Currently, this isn't an issue because we are always starting with Ocarina at the moment, but figured we should account for it while it was on my mind. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2185796208.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2185799554.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2185803190.zip)
<!--- section:artifacts:end -->