### PR TITLE
Check room key flag instead of slot for Stock Pot Inn

### DIFF
--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -117,6 +117,7 @@ typedef enum {
     VB_GIVE_ITEM_FROM_MNK,
     VB_TERMINA_FIELD_BE_EMPTY,
     VB_FASTER_FIRST_CYCLE,
+    VB_CHECK_FOR_ROOM_KEY,
 } GIVanillaBehavior;
 
 typedef enum {

--- a/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
@@ -1,7 +1,9 @@
+#include <libultraship/libultraship.h>
 #include "MiscBehavior.h"
 
 extern "C" {
 #include "variables.h"
+#include "functions.h"
 }
 
 // Entry point for the module, run once on game boot
@@ -26,6 +28,11 @@ void Rando::MiscBehavior::OnFileLoad() {
 
     // Override faster first-cycle time speed if you don't have the Ocarina
     COND_VB_SHOULD(VB_FASTER_FIRST_CYCLE, IS_RANDO, { *should = false; });
+
+    // The game normally only checks the trade slot for the room key directly, which would mean the player could be
+    // denied entry to the Stock Pot Inn if they have the room key but it isn't assigned as the active item for the
+    // slot. In rando, use this flag instead.
+    COND_VB_SHOULD(VB_CHECK_FOR_ROOM_KEY, IS_RANDO, { *should = Flags_GetRandoInf(RANDO_INF_OBTAINED_ROOM_KEY); });
 
     // In Sram_OpenSave (right before this code runs) for non-owl saves, it overwrites the entrance to
     // ENTRANCE(CUTSCENE, 0), we need to override that with our starting location (Harcoded to South Clock Town)

--- a/mm/src/code/z_schedule.c
+++ b/mm/src/code/z_schedule.c
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
 
 #define SCHEDULE_CALC_TIME(hour, minute, dest, temp) \
     (temp) = (hour)*60.0f;                           \
@@ -109,7 +110,8 @@ s32 Schedule_Nop(PlayState* play, u8** script, ScheduleOutput* output) {
 s32 Schedule_CheckMiscS(PlayState* play, u8** script, ScheduleOutput* output) {
     ScheduleCmdCheckMiscS* cmd = (ScheduleCmdCheckMiscS*)*script;
 
-    if (((cmd->which == SCHEDULE_CHECK_MISC_ROOM_KEY) && (INV_CONTENT(ITEM_ROOM_KEY) == ITEM_ROOM_KEY)) ||
+    if (((cmd->which == SCHEDULE_CHECK_MISC_ROOM_KEY) &&
+         GameInteractor_Should(VB_CHECK_FOR_ROOM_KEY, INV_CONTENT(ITEM_ROOM_KEY) == ITEM_ROOM_KEY)) ||
         ((cmd->which == SCHEDULE_CHECK_MISC_LETTER_TO_KAFEI) &&
          (INV_CONTENT(ITEM_LETTER_TO_KAFEI) == ITEM_LETTER_TO_KAFEI)) ||
         ((cmd->which == SCHEDULE_CHECK_MISC_MASK_ROMANI) && (Player_GetMask(play) == PLAYER_MASK_ROMANI))) {

--- a/mm/src/overlays/actors/ovl_En_Time_Tag/z_en_time_tag.c
+++ b/mm/src/overlays/actors/ovl_En_Time_Tag/z_en_time_tag.c
@@ -10,6 +10,7 @@
 
 #include "z_en_time_tag.h"
 #include "overlays/actors/ovl_En_Elf/z_en_elf.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
 
 #define FLAGS (ACTOR_FLAG_10)
 
@@ -318,7 +319,8 @@ void EnTimeTag_KickOut_WaitForTime(EnTimeTag* this, PlayState* play) {
     s16 hour;
     s16 minute;
 
-    if ((play->sceneId == SCENE_YADOYA) && (INV_CONTENT(ITEM_ROOM_KEY) == ITEM_ROOM_KEY)) {
+    if ((play->sceneId == SCENE_YADOYA) &&
+        GameInteractor_Should(VB_CHECK_FOR_ROOM_KEY, INV_CONTENT(ITEM_ROOM_KEY) == ITEM_ROOM_KEY)) {
         // Having the room key allows you to stay in Stock Pot Inn
         return;
     }


### PR DESCRIPTION
The flag-based trade multi-slots thing is great for items that the player must actively use. However, the player does not directly use the room key; the game checks the inventory slot for it directly. If the player obtained the room key but has the letter to mama assigned to it, the game thinks the player does not have it at all. The new hook checks the flag instead.

- Main Stock Pot Inn entrance
- Guest room
- Stock Pot Inn indoors after 8:30 P.M.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2190944459.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2190950089.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2190950819.zip)
<!--- section:artifacts:end -->