### PR TITLE
[Check Tracker][SaveEditor] Update Check Tracker and Save Editor

### DIFF
--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -1200,27 +1200,6 @@ void DrawQuestStatusTab() {
     ImGui::PopItemWidth();
     UIWidgets::PopStyleSlider();
 
-    if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
-        ImGui::SeparatorText("Randomizer Check Status");
-
-        for (auto& [_, randoStaticCheck] : Rando::StaticData::Checks) {
-            RandoSaveCheck& randoSaveCheck = RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId];
-            if (!randoSaveCheck.shuffled) {
-                continue;
-            }
-
-            std::string hiddenName = "##";
-            hiddenName += randoStaticCheck.name;
-            UIWidgets::Checkbox((hiddenName + "eligible").c_str(), &randoSaveCheck.eligible);
-            ImGui::SetItemTooltip("Eligible");
-            ImGui::SameLine();
-            UIWidgets::Checkbox((hiddenName + "obtained").c_str(), &randoSaveCheck.obtained);
-            ImGui::SetItemTooltip("Obtained");
-            // Associated Flag will go here, kinda complicated
-            ImGui::SameLine();
-            ImGui::Text("%s", randoStaticCheck.name);
-        }
-    }
     ImGui::EndChild();
     ImGui::EndChild();
     ImGui::PopStyleVar(2);
@@ -2047,6 +2026,51 @@ void DrawFlagsTab() {
     ImGui::PopStyleVar(2);
 }
 
+void DrawRandoTab() {
+    ImGui::BeginChild("RandoChild");
+    if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
+        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
+
+        ImGui::BeginTable("Check List", 4);
+        ImGui::TableSetupColumn("Eligible", ImGuiTableColumnFlags_NoHeaderLabel | ImGuiTableColumnFlags_WidthFixed, 40.0f);
+        ImGui::TableSetupColumn("Obtained", ImGuiTableColumnFlags_NoHeaderLabel | ImGuiTableColumnFlags_WidthFixed, 40.0f);
+        ImGui::TableSetupColumn("Check Name");
+        ImGui::TableSetupColumn("Reward");
+        ImGui::TableSetupScrollFreeze(4, 1);
+        ImGui::TableHeadersRow();
+
+        for (auto& [_, randoStaticCheck] : Rando::StaticData::Checks) {
+            RandoSaveCheck& randoSaveCheck = RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId];
+            if (!randoSaveCheck.shuffled) {
+                continue;
+            }
+            std::string hiddenName = "##";
+            hiddenName += randoStaticCheck.name;
+            ImGui::TableNextColumn();
+            UIWidgets::Checkbox((hiddenName + "eligible").c_str(), &randoSaveCheck.eligible);
+            UIWidgets::Tooltip("Eligible");
+            ImGui::TableNextColumn();
+            UIWidgets::Checkbox((hiddenName + "obtained").c_str(), &randoSaveCheck.obtained);
+            UIWidgets::Tooltip("Obtained");
+            ImGui::TableNextColumn();
+            ImGui::TextColored(randoSaveCheck.obtained ? UIWidgets::Colors::LightGreen : UIWidgets::Colors::White, randoStaticCheck.name);
+            ImGui::TableNextColumn();
+            if (randoSaveCheck.obtained) {
+                ImGui::TextColored(randoSaveCheck.obtained ? UIWidgets::Colors::LightGreen : UIWidgets::Colors::White, 
+                    Rando::StaticData::Items[randoStaticCheck.randoItemId].name);
+            }
+        }
+
+        ImGui::EndTable();
+        ImGui::PopStyleColor(3);
+    } else {
+        ImGui::Text("No Rando Save Loaded...");
+    }
+    ImGui::EndChild();
+}
+
 void SaveEditorWindow::DrawElement() {
     if (ImGui::BeginTabBar("SaveContextTabBar", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
         if (ImGui::BeginTabItem("General")) {
@@ -2086,6 +2110,11 @@ void SaveEditorWindow::DrawElement() {
 
         if (ImGui::BeginTabItem("Player")) {
             DrawPlayerTab();
+            ImGui::EndTabItem();
+        }
+
+        if (ImGui::BeginTabItem("Rando")) {
+            DrawRandoTab();
             ImGui::EndTabItem();
         }
 

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -2034,8 +2034,10 @@ void DrawRandoTab() {
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
 
         ImGui::BeginTable("Check List", 4);
-        ImGui::TableSetupColumn("Eligible", ImGuiTableColumnFlags_NoHeaderLabel | ImGuiTableColumnFlags_WidthFixed, 40.0f);
-        ImGui::TableSetupColumn("Obtained", ImGuiTableColumnFlags_NoHeaderLabel | ImGuiTableColumnFlags_WidthFixed, 40.0f);
+        ImGui::TableSetupColumn("Eligible", ImGuiTableColumnFlags_NoHeaderLabel | ImGuiTableColumnFlags_WidthFixed,
+                                40.0f);
+        ImGui::TableSetupColumn("Obtained", ImGuiTableColumnFlags_NoHeaderLabel | ImGuiTableColumnFlags_WidthFixed,
+                                40.0f);
         ImGui::TableSetupColumn("Check Name");
         ImGui::TableSetupColumn("Reward");
         ImGui::TableSetupScrollFreeze(4, 1);
@@ -2055,11 +2057,12 @@ void DrawRandoTab() {
             UIWidgets::Checkbox((hiddenName + "obtained").c_str(), &randoSaveCheck.obtained);
             UIWidgets::Tooltip("Obtained");
             ImGui::TableNextColumn();
-            ImGui::TextColored(randoSaveCheck.obtained ? UIWidgets::Colors::LightGreen : UIWidgets::Colors::White, randoStaticCheck.name);
+            ImGui::TextColored(randoSaveCheck.obtained ? UIWidgets::Colors::LightGreen : UIWidgets::Colors::White,
+                               randoStaticCheck.name);
             ImGui::TableNextColumn();
             if (randoSaveCheck.obtained) {
-                ImGui::TextColored(randoSaveCheck.obtained ? UIWidgets::Colors::LightGreen : UIWidgets::Colors::White, 
-                    Rando::StaticData::Items[randoStaticCheck.randoItemId].name);
+                ImGui::TextColored(randoSaveCheck.obtained ? UIWidgets::Colors::LightGreen : UIWidgets::Colors::White,
+                                   Rando::StaticData::Items[randoStaticCheck.randoItemId].name);
             }
         }
 

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
@@ -4,51 +4,169 @@
 #include "2s2h/ShipUtils.h"
 #include "2s2h/BenGui/UIWidgets.hpp"
 
+bool showLogic = false;
+bool expandHeader = true;
+
+std::vector<std::tuple<std::string, SceneId, bool, bool>> sceneCheckList;
+
+std::string convertToReadableName(const std::string& input) {
+    std::string result;
+    std::string content = input;
+
+    // Step 1: Remove "RC_" prefix if present
+    const std::string prefix = "RC_";
+    if (content.rfind(prefix, 0) == 0) {
+        content = content.substr(prefix.size());
+    }
+
+    // Step 2: Split the string by '_'
+    std::vector<std::string> words;
+    std::string word;
+    std::istringstream stream(content);
+    while (std::getline(stream, word, '_')) {
+        words.push_back(word);
+    }
+
+    // Step 3: Capitalize the first letter of each word
+    for (auto& w : words) {
+        std::transform(w.begin(), w.end(), w.begin(), [](unsigned char c) { return std::tolower(c); });
+        if (!w.empty()) {
+            w[0] = std::toupper(w[0]);
+        }
+    }
+
+    // Step 4: Join the words with spaces
+    for (size_t i = 0; i < words.size(); ++i) {
+        result += words[i];
+        if (i < words.size() - 1) {
+            result += " ";
+        }
+    }
+
+    return result;
+}
+
 namespace Rando {
 
 namespace CheckTracker {
 
-void Window::DrawElement() {
-    std::set<RandoRegionId> reachableRegions = {};
-    // Get connected entrances from starting & warp points
-    Rando::Logic::FindReachableRegions(RR_MAX, reachableRegions);
-    // Get connected regions from current entrance (TODO: Make this optional)
-    Rando::Logic::FindReachableRegions(Rando::Logic::GetRegionIdFromEntrance(gSaveContext.save.entrance),
-                                       reachableRegions);
-
-    for (RandoRegionId regionId : reachableRegions) {
-        auto& randoRegion = Rando::Logic::Regions[regionId];
-        std::vector<std::pair<RandoCheckId, std::string>> availableChecks;
-
-        for (auto& [randoCheckId, accessLogicFunc] : randoRegion.checks) {
-            auto& randoStaticCheck = Rando::StaticData::Checks[randoCheckId];
-            auto& randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
-            if (randoSaveCheck.shuffled && !randoSaveCheck.obtained && accessLogicFunc.first()) {
-                availableChecks.push_back({ randoCheckId, accessLogicFunc.second });
-            }
-        }
-
-        if (availableChecks.size() > 0) {
-            std::string regionName = Ship_GetSceneName(randoRegion.sceneId);
-            if (randoRegion.name != "") {
-                regionName += " - ";
-                regionName += randoRegion.name;
-            }
-            ImGui::SeparatorText(regionName.c_str());
-
-            for (auto& [checkId, accessLogicString] : availableChecks) {
-                auto& randoStaticCheck = Rando::StaticData::Checks[checkId];
-                ImGui::Text("%s", randoStaticCheck.name);
-                if (accessLogicString != "") {
-                    UIWidgets::Tooltip(accessLogicString.c_str());
+void CheckTrackerUpdateSceneList(int32_t action) {
+    if (action == SCENE_LOAD) {
+        for (auto& [_, randoStaticCheck] : Rando::StaticData::Checks) {
+            bool sceneExists = false;
+            RandoSaveCheck& randoSaveCheck = RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId];
+            for (auto& scene : sceneCheckList) {
+                sceneExists = false;
+                if (std::get<1>(scene) == randoStaticCheck.sceneId) {
+                    sceneExists = true;
+                    break;
                 }
             }
+            if (!sceneExists) {
+                sceneCheckList.push_back(std::make_tuple(Ship_GetSceneName(randoStaticCheck.sceneId), 
+                    randoStaticCheck.sceneId, true, false));
+            }
+        }
+    } else {
+        for (auto& scene : sceneCheckList) {
+            std::get<2>(scene) = expandHeader;
+            std::get<3>(scene) = false;
+        }
+    }
+}
+
+void Window::DrawElement() {
+    if (showLogic) {
+        std::set<RandoRegionId> reachableRegions = {};
+        // Get connected entrances from starting & warp points
+        Rando::Logic::FindReachableRegions(RR_MAX, reachableRegions);
+        // Get connected regions from current entrance (TODO: Make this optional)
+        Rando::Logic::FindReachableRegions(Rando::Logic::GetRegionIdFromEntrance(gSaveContext.save.entrance),
+                                           reachableRegions);
+
+        for (RandoRegionId regionId : reachableRegions) {
+            auto& randoRegion = Rando::Logic::Regions[regionId];
+            std::vector<std::pair<RandoCheckId, std::string>> availableChecks;
+
+            for (auto& [randoCheckId, accessLogicFunc] : randoRegion.checks) {
+                auto& randoStaticCheck = Rando::StaticData::Checks[randoCheckId];
+                auto& randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
+                if (randoSaveCheck.shuffled && !randoSaveCheck.obtained && accessLogicFunc.first()) {
+                    availableChecks.push_back({ randoCheckId, accessLogicFunc.second });
+                }
+            }
+
+            if (availableChecks.size() > 0) {
+                std::string regionName = Ship_GetSceneName(randoRegion.sceneId);
+                if (randoRegion.name != "") {
+                    regionName += " - ";
+                    regionName += randoRegion.name;
+                }
+                ImGui::SeparatorText(regionName.c_str());
+
+                for (auto& [checkId, accessLogicString] : availableChecks) {
+                    auto& randoStaticCheck = Rando::StaticData::Checks[checkId];
+                    ImGui::Text("%s", randoStaticCheck.name);
+                    if (accessLogicString != "") {
+                        UIWidgets::Tooltip(accessLogicString.c_str());
+                    }
+                }
+            }
+        }
+    } else {
+        for (auto& scene : sceneCheckList) {
+            if (std::get<0>(scene) == "Unknown") {
+                continue;
+            }
+            ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
+            ImGui::Separator();
+            if (!std::get<3>(scene)) {
+                ImGui::SetNextItemOpen(std::get<2>(scene));
+                std::get<3>(scene) = true;
+            }
+            if (ImGui::CollapsingHeader(std::get<0>(scene).c_str())) {
+                ImGui::Indent(20.0f);
+                for (auto& [_, randoStaticCheck] : Rando::StaticData::Checks) {
+                    if (std::get<1>(scene) == randoStaticCheck.sceneId) {
+                        RandoSaveCheck& randoSaveCheck = RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId];
+                        if (!randoSaveCheck.shuffled) {
+                            continue;
+                        }
+                        ImGui::PushStyleColor(ImGuiCol_Text, randoSaveCheck.obtained ? 
+                            UIWidgets::Colors::LightGreen : UIWidgets::Colors::White);
+                        ImGui::Text(convertToReadableName(randoStaticCheck.name).c_str());
+                        if (randoSaveCheck.obtained) {
+                            ImGui::SameLine(0, 50.0f);
+                            std::string itemName = "(" + convertToReadableName(Rando::StaticData::Items[randoSaveCheck.randoItemId].name) + ")";
+                            ImGui::Text(itemName.c_str());
+                        }
+                        ImGui::PopStyleColor();
+                    }
+                }
+                ImGui::Unindent(20.0f);
+            }
+            if (ImGui::IsItemClicked(ImGuiMouseButton_Left)) {
+                bool isExpanded = std::get<2>(scene);
+                std::get<2>(scene) = !isExpanded; // Toggle the bool
+            }
+            ImGui::PopStyleColor(1);
         }
     }
 }
 
 void SettingsWindow::DrawElement() {
-    ImGui::Text("Check Tracker Settings");
+    ImGui::SeparatorText("Check Tracker Settings");
+    UIWidgets::Checkbox("Show Available", &showLogic);
+    if (ImGui::Button("Expand/Collapse All")) {
+        expandHeader = !expandHeader;
+        CheckTrackerUpdateSceneList(SCENE_UPDATE);
+    }
+}
+
+void Window::InitElement() {
+    COND_HOOK(OnSaveLoad, &gSaveContext.save.shipSaveInfo.rando, [](uint32_t fileNum) {
+        CheckTrackerUpdateSceneList(SCENE_LOAD);
+    });
 }
 
 } // namespace CheckTracker

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
@@ -6,9 +6,10 @@
 
 bool showLogic = false;
 bool hideCollected = false;
+bool updateHeaders = false;
 bool expandHeader = true;
 
-std::vector<std::tuple<std::string, SceneId, bool, bool>> sceneCheckList;
+std::vector<std::tuple<std::string, SceneId, bool, bool, uint32_t>> sceneCheckList;
 
 std::string convertToReadableName(const std::string& input) {
     std::string result;
@@ -47,6 +48,19 @@ std::string convertToReadableName(const std::string& input) {
     return result;
 }
 
+uint32_t totalCheckAmount(SceneId sceneId) {
+    uint32_t collected = 0;
+    for (auto& [_, randoStaticCheck] : Rando::StaticData::Checks) {
+        RandoSaveCheck& randoSaveCheck = RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId];
+        if (sceneId == randoStaticCheck.sceneId) {
+            if (randoSaveCheck.obtained) {
+                collected++;
+            }
+        }
+    }
+    return collected;
+}
+
 namespace Rando {
 
 namespace CheckTracker {
@@ -60,12 +74,13 @@ void CheckTrackerUpdateSceneList(int32_t action) {
                 sceneExists = false;
                 if (std::get<1>(scene) == randoStaticCheck.sceneId) {
                     sceneExists = true;
+                    std::get<4>(scene)++;
                     break;
                 }
             }
             if (!sceneExists) {
                 sceneCheckList.push_back(std::make_tuple(Ship_GetSceneName(randoStaticCheck.sceneId),
-                                                         randoStaticCheck.sceneId, true, false));
+                                                         randoStaticCheck.sceneId, true, false, 1));
             }
         }
     } else {
@@ -127,13 +142,24 @@ void Window::DrawElement() {
             if (std::get<0>(scene) == "Unknown") {
                 continue;
             }
+            ImGui::PushID(std::get<1>(scene));
             ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
+            uint32_t popCount = 1;
             ImGui::Separator();
-            if (!std::get<3>(scene)) {
-                ImGui::SetNextItemOpen(std::get<2>(scene));
-                std::get<3>(scene) = true;
+            uint32_t collectedChecks = totalCheckAmount(std::get<1>(scene));
+            std::string headerText = std::get<0>(scene).c_str();
+            headerText += " (" + std::to_string(collectedChecks) + "/" + std::to_string(std::get<4>(scene)) + ")";
+            if (collectedChecks == std::get<4>(scene)) {
+                ImGui::PushStyleColor(ImGuiCol_Text, UIWidgets::Colors::LightGreen);
+                popCount++;
             }
-            if (ImGui::CollapsingHeader(std::get<0>(scene).c_str())) {
+            bool shouldExpand = std::get<2>(scene);
+            if (updateHeaders) {
+                ImGui::SetNextItemOpen(shouldExpand);
+            } else {
+                ImGui::SetNextItemOpen(shouldExpand, ImGuiCond_Once);
+            }
+            if (ImGui::CollapsingHeader(headerText.c_str())) {
                 ImGui::Indent(20.0f);
                 for (auto& [_, randoStaticCheck] : Rando::StaticData::Checks) {
                     if (std::get<1>(scene) == randoStaticCheck.sceneId) {
@@ -159,12 +185,14 @@ void Window::DrawElement() {
                 }
                 ImGui::Unindent(20.0f);
             }
-            if (ImGui::IsItemClicked(ImGuiMouseButton_Left)) {
+            if (ImGui::IsItemClicked()) {
                 bool isExpanded = std::get<2>(scene);
                 std::get<2>(scene) = !isExpanded;
             }
-            ImGui::PopStyleColor(1);
+            ImGui::PopStyleColor(popCount);
+            ImGui::PopID();
         }
+        updateHeaders = false;
     }
 }
 
@@ -174,6 +202,7 @@ void SettingsWindow::DrawElement() {
     UIWidgets::Checkbox("Hide Collected", &hideCollected);
     if (ImGui::Button("Expand/Collapse All")) {
         expandHeader = !expandHeader;
+        updateHeaders = true;
         CheckTrackerUpdateSceneList(SCENE_UPDATE);
     }
 }

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
@@ -5,6 +5,7 @@
 #include "2s2h/BenGui/UIWidgets.hpp"
 
 bool showLogic = false;
+bool hideCollected = false;
 bool expandHeader = true;
 
 std::vector<std::tuple<std::string, SceneId, bool, bool>> sceneCheckList;
@@ -75,6 +76,14 @@ void CheckTrackerUpdateSceneList(int32_t action) {
     }
 }
 
+bool checkTrackerShouldShowRow(bool obtained) {
+    bool showCheck = true;
+    if (hideCollected && obtained) {
+        showCheck = false;
+    }
+    return showCheck;
+}
+
 void Window::DrawElement() {
     if (showLogic) {
         std::set<RandoRegionId> reachableRegions = {};
@@ -134,11 +143,15 @@ void Window::DrawElement() {
                         }
                         ImGui::PushStyleColor(ImGuiCol_Text, randoSaveCheck.obtained ? 
                             UIWidgets::Colors::LightGreen : UIWidgets::Colors::White);
-                        ImGui::Text(convertToReadableName(randoStaticCheck.name).c_str());
-                        if (randoSaveCheck.obtained) {
-                            ImGui::SameLine(0, 50.0f);
-                            std::string itemName = "(" + convertToReadableName(Rando::StaticData::Items[randoSaveCheck.randoItemId].name) + ")";
-                            ImGui::Text(itemName.c_str());
+                        if (checkTrackerShouldShowRow(randoSaveCheck.obtained)) {
+                            ImGui::Text(convertToReadableName(randoStaticCheck.name).c_str());
+                            if (randoSaveCheck.obtained) {
+                                ImGui::SameLine(0, 50.0f);
+                                std::string itemName = "(";
+                                itemName += convertToReadableName(Rando::StaticData::Items[randoSaveCheck.randoItemId].name);
+                                itemName += ")";
+                                ImGui::Text(itemName.c_str());
+                            }
                         }
                         ImGui::PopStyleColor();
                     }
@@ -147,7 +160,7 @@ void Window::DrawElement() {
             }
             if (ImGui::IsItemClicked(ImGuiMouseButton_Left)) {
                 bool isExpanded = std::get<2>(scene);
-                std::get<2>(scene) = !isExpanded; // Toggle the bool
+                std::get<2>(scene) = !isExpanded;
             }
             ImGui::PopStyleColor(1);
         }
@@ -156,7 +169,8 @@ void Window::DrawElement() {
 
 void SettingsWindow::DrawElement() {
     ImGui::SeparatorText("Check Tracker Settings");
-    UIWidgets::Checkbox("Show Available", &showLogic);
+    UIWidgets::Checkbox("Show Logic", &showLogic);
+    UIWidgets::Checkbox("Hide Collected", &hideCollected);
     if (ImGui::Button("Expand/Collapse All")) {
         expandHeader = !expandHeader;
         CheckTrackerUpdateSceneList(SCENE_UPDATE);

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
@@ -64,8 +64,8 @@ void CheckTrackerUpdateSceneList(int32_t action) {
                 }
             }
             if (!sceneExists) {
-                sceneCheckList.push_back(std::make_tuple(Ship_GetSceneName(randoStaticCheck.sceneId), 
-                    randoStaticCheck.sceneId, true, false));
+                sceneCheckList.push_back(std::make_tuple(Ship_GetSceneName(randoStaticCheck.sceneId),
+                                                         randoStaticCheck.sceneId, true, false));
             }
         }
     } else {
@@ -141,14 +141,15 @@ void Window::DrawElement() {
                         if (!randoSaveCheck.shuffled) {
                             continue;
                         }
-                        ImGui::PushStyleColor(ImGuiCol_Text, randoSaveCheck.obtained ? 
-                            UIWidgets::Colors::LightGreen : UIWidgets::Colors::White);
+                        ImGui::PushStyleColor(ImGuiCol_Text, randoSaveCheck.obtained ? UIWidgets::Colors::LightGreen
+                                                                                     : UIWidgets::Colors::White);
                         if (checkTrackerShouldShowRow(randoSaveCheck.obtained)) {
                             ImGui::Text(convertToReadableName(randoStaticCheck.name).c_str());
                             if (randoSaveCheck.obtained) {
                                 ImGui::SameLine(0, 50.0f);
                                 std::string itemName = "(";
-                                itemName += convertToReadableName(Rando::StaticData::Items[randoSaveCheck.randoItemId].name);
+                                itemName +=
+                                    convertToReadableName(Rando::StaticData::Items[randoSaveCheck.randoItemId].name);
                                 itemName += ")";
                                 ImGui::Text(itemName.c_str());
                             }
@@ -178,9 +179,8 @@ void SettingsWindow::DrawElement() {
 }
 
 void Window::InitElement() {
-    COND_HOOK(OnSaveLoad, &gSaveContext.save.shipSaveInfo.rando, [](uint32_t fileNum) {
-        CheckTrackerUpdateSceneList(SCENE_LOAD);
-    });
+    COND_HOOK(OnSaveLoad, &gSaveContext.save.shipSaveInfo.rando,
+              [](uint32_t fileNum) { CheckTrackerUpdateSceneList(SCENE_LOAD); });
 }
 
 } // namespace CheckTracker

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.h
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.h
@@ -30,9 +30,6 @@ class SettingsWindow : public Ship::GuiWindow {
 
 } // namespace Rando
 
-typedef enum {
-    SCENE_LOAD,
-    SCENE_UPDATE
-};
+typedef enum { SCENE_LOAD, SCENE_UPDATE };
 
 #endif // RANDO_CHECK_TRACKER_H

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.h
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.h
@@ -12,7 +12,7 @@ class Window : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 
-    void InitElement() override{};
+    void InitElement();
     void DrawElement() override;
     void UpdateElement() override{};
 };
@@ -29,5 +29,10 @@ class SettingsWindow : public Ship::GuiWindow {
 } // namespace CheckTracker
 
 } // namespace Rando
+
+typedef enum {
+    SCENE_LOAD,
+    SCENE_UPDATE
+};
 
 #endif // RANDO_CHECK_TRACKER_H

--- a/mm/2s2h/Rando/Menu.cpp
+++ b/mm/2s2h/Rando/Menu.cpp
@@ -53,14 +53,16 @@ void Rando::DrawMenu() {
                 UIWidgets::CVarCheckbox("Shuffle Shops", Rando::StaticData::Options[RO_SHUFFLE_SHOPS].cvar);
             }
         }
-
-        UIWidgets::WindowButton("Check Tracker", "gWindows.CheckTracker", BenGui::mRandoCheckTrackerWindow);
+        UIWidgets::WindowButton("Check Tracker", "gWindows.CheckTracker", BenGui::mRandoCheckTrackerWindow, {
+                .size = ImVec2((ImGui::GetContentRegionAvail().x - 48.0f), 32.0f)
+            });
         // TODO: Implement Check Tracker Settings
-        // ImGui::SameLine();
-        // UIWidgets::WindowButton(ICON_FA_COG, "gWindows.CheckTrackerSettings",
-        // BenGui::mRandoCheckTrackerSettingsWindow,
-        //                         { .size = UIWidgets::Sizes::Inline });
-
+        ImGui::SameLine();
+        if (UIWidgets::Button(ICON_FA_COG, {
+                .size = ImVec2(32.0f, 32.0f)
+            })) {
+            BenGui::mRandoCheckTrackerSettingsWindow->ToggleVisibility();
+        }
         ImGui::EndMenu();
     }
 }

--- a/mm/2s2h/Rando/Menu.cpp
+++ b/mm/2s2h/Rando/Menu.cpp
@@ -53,14 +53,11 @@ void Rando::DrawMenu() {
                 UIWidgets::CVarCheckbox("Shuffle Shops", Rando::StaticData::Options[RO_SHUFFLE_SHOPS].cvar);
             }
         }
-        UIWidgets::WindowButton("Check Tracker", "gWindows.CheckTracker", BenGui::mRandoCheckTrackerWindow, {
-                .size = ImVec2((ImGui::GetContentRegionAvail().x - 48.0f), 32.0f)
-            });
+        UIWidgets::WindowButton("Check Tracker", "gWindows.CheckTracker", BenGui::mRandoCheckTrackerWindow,
+                                { .size = ImVec2((ImGui::GetContentRegionAvail().x - 48.0f), 32.0f) });
         // TODO: Implement Check Tracker Settings
         ImGui::SameLine();
-        if (UIWidgets::Button(ICON_FA_COG, {
-                .size = ImVec2(32.0f, 32.0f)
-            })) {
+        if (UIWidgets::Button(ICON_FA_COG, { .size = ImVec2(32.0f, 32.0f) })) {
             BenGui::mRandoCheckTrackerSettingsWindow->ToggleVisibility();
         }
         ImGui::EndMenu();


### PR DESCRIPTION
Adds full functionality to the Check Tracker for Logicless Play, also moves the Rando stuff from Quest tab in Save Editor to its own tab.

Finished Implementing the Check Tracker Settings Window.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2226994204.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2226996229.zip)
<!--- section:artifacts:end -->