### PR TITLE
Ignore OnSceneFlagSet if check type is RCTYPE_POT

### DIFF
--- a/mm/2s2h/Rando/MiscBehavior/OnFlagSet.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFlagSet.cpp
@@ -22,6 +22,11 @@ void Rando::MiscBehavior::OnSceneFlagSet(s16 sceneId, FlagType flagType, u32 fla
         return;
     }
 
+    // Pots handle their own items, ignore them
+    if (randoStaticCheck.randoCheckType == RCTYPE_POT) {
+        return;
+    }
+
     auto& randoSaveCheck = RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId];
     if (randoSaveCheck.shuffled) {
         randoSaveCheck.eligible = true;


### PR DESCRIPTION
As is, pots drop their vanilla items after the randomized item has been obtained. Picking up a pot collectible ultimately calls `OnSceneFlagSet`, meaning the converted rando item will be obtained in addition to the vanilla pickup. This fix precludes the `OnSceneFlagSet` call for pot checks, leaving only the vanilla item for repeat pickups. This change matches the `InitEnItem00Behavior` condition that ensures the vanilla item model is what gets spawned for repeats:

https://github.com/garrettjoecox/2ship2harkinian/blob/1b5fb29a652a3507b629cf4e50cb6963b7c8e761/mm/2s2h/Rando/ActorBehavior/EnItem00.cpp#L25-L28

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2236664440.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2236670539.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2236671310.zip)
<!--- section:artifacts:end -->