### PR TITLE
Stone Tower Temple Adjustments

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
@@ -696,75 +696,6 @@ RandoCheckId IdentifyPot(Actor* actor) {
             }
             break;
         case SCENE_INISIE_N:
-            if (IS_AT(2070.0f, -1620.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_1;
-            }
-            if (IS_AT(2790.0f, -1620.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_2;
-            }
-            if (IS_AT(2790.0f, -900.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_3;
-            }
-            if (IS_AT(2070.0f, -900.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_4;
-            }
-            if (IS_AT(-735.0f, -1305.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_MAZE_SIDE_1;
-            }
-            if (IS_AT(-735.0f, -1305.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_MAZE_SIDE_2;
-            }
-            if (IS_AT(-1605.0f, -1395.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_WIZZROBE_SIDE_1;
-            }
-            if (IS_AT(-1605.0f, -1305.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_WIZZROBE_SIDE_2;
-            }
-            if (IS_AT(-30.0f, -1995.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_1;
-            }
-            if (IS_AT(-30.0f, -1965.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_2;
-            }
-            if (IS_AT(-30.0f, -1935.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_3;
-            }
-            if (IS_AT(-30.0f, -1905.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_4;
-            }
-            if (IS_AT(30.0f, -1995.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_5;
-            }
-            if (IS_AT(30.0f, -1965.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_6;
-            }
-            if (IS_AT(30.0f, -1935.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_7;
-            }
-            if (IS_AT(30.0f, -1905.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_8;
-            }
-            if (IS_AT(1350.0f, -630.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_BRIDGE_1;
-            }
-            if (IS_AT(1230.0f, -630.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_BRIDGE_2;
-            }
-            if (IS_AT(735.0f, -1305.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_LEDGE_3;
-            }
-            if (IS_AT(-1290.0f, -510.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_1;
-            }
-            if (IS_AT(-1290.0f, -450.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_2;
-            }
-            if (IS_AT(-1410.0f, -450.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_3;
-            }
-            if (IS_AT(-1410.0f, -510.0f)) {
-                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_4;
-            }
             // if (IS_AT(-30.0f, -1995.0f)) {
             //     randoCheckId = RC_STONE_TOWER_TEMPLE_POT_BEFORE_WATER_BRIDGE_1;
             // }
@@ -842,6 +773,77 @@ RandoCheckId IdentifyPot(Actor* actor) {
             }
             if (IS_AT(585.0f, -3465.0f)) {
                 randoCheckId = RC_STONE_TOWER_TEMPLE_POT_WIND_ROOM_4;
+            }
+            break;
+        case SCENE_INISIE_R:
+            if (IS_AT(2070.0f, -1620.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_1;
+            }
+            if (IS_AT(2790.0f, -1620.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_2;
+            }
+            if (IS_AT(2790.0f, -900.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_3;
+            }
+            if (IS_AT(2070.0f, -900.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_4;
+            }
+            if (IS_AT(-735.0f, -1305.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_MAZE_SIDE_1;
+            }
+            if (IS_AT(-735.0f, -1305.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_MAZE_SIDE_2;
+            }
+            if (IS_AT(-1605.0f, -1395.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_WIZZROBE_SIDE_1;
+            }
+            if (IS_AT(-1605.0f, -1305.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_WIZZROBE_SIDE_2;
+            }
+            if (IS_AT(-30.0f, -1995.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_1;
+            }
+            if (IS_AT(-30.0f, -1965.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_2;
+            }
+            if (IS_AT(-30.0f, -1935.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_3;
+            }
+            if (IS_AT(-30.0f, -1905.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_4;
+            }
+            if (IS_AT(30.0f, -1995.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_5;
+            }
+            if (IS_AT(30.0f, -1965.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_6;
+            }
+            if (IS_AT(30.0f, -1935.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_7;
+            }
+            if (IS_AT(30.0f, -1905.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_8;
+            }
+            if (IS_AT(1350.0f, -630.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_BRIDGE_1;
+            }
+            if (IS_AT(1230.0f, -630.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_BRIDGE_2;
+            }
+            if (IS_AT(735.0f, -1305.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_LEDGE_3;
+            }
+            if (IS_AT(-1290.0f, -510.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_1;
+            }
+            if (IS_AT(-1290.0f, -450.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_2;
+            }
+            if (IS_AT(-1410.0f, -450.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_3;
+            }
+            if (IS_AT(-1410.0f, -510.0f)) {
+                randoCheckId = RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_4;
             }
             break;
         default:

--- a/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
@@ -12,7 +12,8 @@ extern "C" {
 #define IS_AT(xx, zz) (actor->home.pos.x == xx && actor->home.pos.z == zz)
 
 RandoCheckId IdentifyPot(Actor* actor) {
-    auto randoStaticCheck = Rando::StaticData::GetCheckForPot(OBJ_TSUBO_PFE00(actor), gPlayState->sceneId);
+    auto randoStaticCheck =
+        Rando::StaticData::GetCheckFromFlag(FLAG_CYCL_SCENE_COLLECTIBLE, OBJ_TSUBO_PFE00(actor), gPlayState->sceneId);
     if (randoStaticCheck.randoCheckId != RC_UNKNOWN) {
         return randoStaticCheck.randoCheckId;
     }

--- a/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
@@ -12,8 +12,7 @@ extern "C" {
 #define IS_AT(xx, zz) (actor->home.pos.x == xx && actor->home.pos.z == zz)
 
 RandoCheckId IdentifyPot(Actor* actor) {
-    auto randoStaticCheck =
-        Rando::StaticData::GetCheckFromFlag(FLAG_CYCL_SCENE_COLLECTIBLE, OBJ_TSUBO_PFE00(actor), gPlayState->sceneId);
+    auto randoStaticCheck = Rando::StaticData::GetCheckForPot(OBJ_TSUBO_PFE00(actor), gPlayState->sceneId);
     if (randoStaticCheck.randoCheckId != RC_UNKNOWN) {
         return randoStaticCheck.randoCheckId;
     }

--- a/mm/2s2h/Rando/StaticData/Checks.cpp
+++ b/mm/2s2h/Rando/StaticData/Checks.cpp
@@ -862,8 +862,8 @@ std::map<RandoCheckId, RandoStaticCheck> Checks = {
 // should keep an eye on performance, because this is used in various draw calls. One possible optimization is to create
 // a hash map from the list of checks but that seems overkill for now.
 RandoStaticCheck GetCheckFromFlag(FlagType flagType, s32 flag, s16 sceneId) {
-    // Exclude converting Inverted Stone Tower Temple for collectible flags. Cleared room flags should also be excluded, but there
-    // aren't any checks for that flagType.
+    // Exclude converting Inverted Stone Tower Temple for collectible flags. Cleared room flags should also be excluded,
+    // but there aren't any checks for that flagType.
     if (!(sceneId == SCENE_INISIE_R && flagType == FLAG_CYCL_SCENE_COLLECTIBLE)) {
         sceneId = Play_GetOriginalSceneId(sceneId);
     }

--- a/mm/2s2h/Rando/StaticData/Checks.cpp
+++ b/mm/2s2h/Rando/StaticData/Checks.cpp
@@ -725,33 +725,33 @@ std::map<RandoCheckId, RandoStaticCheck> Checks = {
     RC(RC_STONE_TOWER_POT_OWL_STATUE_2,                         RCTYPE_POT,              SCENE_F40,                      FLAG_CYCL_SCENE_COLLECTIBLE, 0x38,                                                                RI_ARROWS_30),
     RC(RC_STONE_TOWER_POT_OWL_STATUE_3,                         RCTYPE_POT,              SCENE_F40,                      FLAG_CYCL_SCENE_COLLECTIBLE, 0x39,                                                                RI_FAIRY_REFILL),
     RC(RC_STONE_TOWER_POT_OWL_STATUE_4,                         RCTYPE_POT,              SCENE_F40,                      FLAG_CYCL_SCENE_COLLECTIBLE, 0x3a,                                                                RI_MAGIC_JAR_BIG),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_1,             RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_2,             RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_3,             RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_4,             RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_MAZE_SIDE_1,      RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_MAZE_SIDE_2,      RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_ARROWS_10),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_WIZZROBE_SIDE_1,  RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_WIZZROBE_SIDE_2,  RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_MAGIC_JAR_SMALL),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_1,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_2,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_3,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_4,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_5,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_MAGIC_JAR_BIG),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_6,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_MAGIC_JAR_BIG),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_7,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_BOMBS_5),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_8,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_ARROWS_10),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_BRIDGE_1,    RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_ARROWS_10),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_BRIDGE_2,    RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_ARROWS_10),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_LEDGE_1,     RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_CYCL_SCENE_COLLECTIBLE, 0x24,                                                                RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_LEDGE_2,     RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_CYCL_SCENE_COLLECTIBLE, 0x22,                                                                RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_LEDGE_3,     RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_LEDGE_4,     RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_CYCL_SCENE_COLLECTIBLE, 0x23,                                                                RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_1,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_ARROWS_10),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_2,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_BOMBS_5),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_3,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_4,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_MAGIC_JAR_BIG),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_5,           RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_CYCL_SCENE_COLLECTIBLE, 0x21,                                                                RI_FAIRY_REFILL),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_1,             RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_2,             RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_3,             RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_GOMESS_4,             RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_MAZE_SIDE_1,      RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_MAZE_SIDE_2,      RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_ARROWS_10),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_WIZZROBE_SIDE_1,  RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_POE_WIZZROBE_SIDE_2,  RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_MAGIC_JAR_SMALL),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_1,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_2,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_3,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_4,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_5,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_MAGIC_JAR_BIG),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_6,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_MAGIC_JAR_BIG),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_7,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_BOMBS_5),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_PRE_BOSS_8,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_ARROWS_10),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_BRIDGE_1,    RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_ARROWS_10),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_BRIDGE_2,    RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_ARROWS_10),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_LEDGE_1,     RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_CYCL_SCENE_COLLECTIBLE, 0x24,                                                                RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_LEDGE_2,     RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_CYCL_SCENE_COLLECTIBLE, 0x22,                                                                RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_LEDGE_3,     RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_UPDRAFTS_LEDGE_4,     RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_CYCL_SCENE_COLLECTIBLE, 0x23,                                                                RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_1,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_ARROWS_10),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_2,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_BOMBS_5),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_3,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_4,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_NONE,                   0x0,                                                                 RI_MAGIC_JAR_BIG),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_POT_WIZZROBE_5,           RCTYPE_POT,              SCENE_INISIE_R,                 FLAG_CYCL_SCENE_COLLECTIBLE, 0x21,                                                                RI_FAIRY_REFILL),
     // RC(RC_STONE_TOWER_TEMPLE_POT_BEFORE_WATER_BRIDGE_1,         RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
     // RC(RC_STONE_TOWER_TEMPLE_POT_BEFORE_WATER_BRIDGE_2,         RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
     // RC(RC_STONE_TOWER_TEMPLE_POT_BEFORE_WATER_BRIDGE_3,         RCTYPE_POT,              SCENE_INISIE_N,                 FLAG_NONE,                   0x0,                                                                 RI_RECOVERY_HEART),
@@ -862,10 +862,19 @@ std::map<RandoCheckId, RandoStaticCheck> Checks = {
 // should keep an eye on performance, because this is used in various draw calls. One possible optimization is to create
 // a hash map from the list of checks but that seems overkill for now.
 RandoStaticCheck GetCheckFromFlag(FlagType flagType, s32 flag, s16 sceneId) {
-    sceneId = Play_GetOriginalSceneId(sceneId);
-
     for (auto& [check, data] : Checks) {
-        if (data.flagType == flagType && data.flag == flag && (sceneId == SCENE_MAX || data.sceneId == sceneId)) {
+        if (data.flagType == flagType && data.flag == flag &&
+            (sceneId == SCENE_MAX || data.sceneId == Play_GetOriginalSceneId(sceneId))) {
+            return data;
+        }
+    }
+    return Checks[RC_UNKNOWN];
+}
+
+RandoStaticCheck GetCheckForPot(s32 flag, s16 sceneId) {
+    for (auto& [check, data] : Checks) {
+        if (data.flagType == FLAG_CYCL_SCENE_COLLECTIBLE && data.flag == flag &&
+            (sceneId == SCENE_MAX || data.sceneId == sceneId)) {
             return data;
         }
     }

--- a/mm/2s2h/Rando/StaticData/Checks.cpp
+++ b/mm/2s2h/Rando/StaticData/Checks.cpp
@@ -862,19 +862,14 @@ std::map<RandoCheckId, RandoStaticCheck> Checks = {
 // should keep an eye on performance, because this is used in various draw calls. One possible optimization is to create
 // a hash map from the list of checks but that seems overkill for now.
 RandoStaticCheck GetCheckFromFlag(FlagType flagType, s32 flag, s16 sceneId) {
-    for (auto& [check, data] : Checks) {
-        if (data.flagType == flagType && data.flag == flag &&
-            (sceneId == SCENE_MAX || data.sceneId == Play_GetOriginalSceneId(sceneId))) {
-            return data;
-        }
+    // Exclude Inverted Stone Tower Temple for collectible flags. Cleared room flags should also be excluded, but there
+    // aren't any checks for that flagType.
+    if (sceneId == SCENE_INISIE_R && flagType != FLAG_CYCL_SCENE_COLLECTIBLE) {
+        sceneId = Play_GetOriginalSceneId(sceneId);
     }
-    return Checks[RC_UNKNOWN];
-}
 
-RandoStaticCheck GetCheckForPot(s32 flag, s16 sceneId) {
     for (auto& [check, data] : Checks) {
-        if (data.flagType == FLAG_CYCL_SCENE_COLLECTIBLE && data.flag == flag &&
-            (sceneId == SCENE_MAX || data.sceneId == sceneId)) {
+        if (data.flagType == flagType && data.flag == flag && (sceneId == SCENE_MAX || data.sceneId == sceneId)) {
             return data;
         }
     }

--- a/mm/2s2h/Rando/StaticData/Checks.cpp
+++ b/mm/2s2h/Rando/StaticData/Checks.cpp
@@ -862,9 +862,9 @@ std::map<RandoCheckId, RandoStaticCheck> Checks = {
 // should keep an eye on performance, because this is used in various draw calls. One possible optimization is to create
 // a hash map from the list of checks but that seems overkill for now.
 RandoStaticCheck GetCheckFromFlag(FlagType flagType, s32 flag, s16 sceneId) {
-    // Exclude Inverted Stone Tower Temple for collectible flags. Cleared room flags should also be excluded, but there
+    // Exclude converting Inverted Stone Tower Temple for collectible flags. Cleared room flags should also be excluded, but there
     // aren't any checks for that flagType.
-    if (sceneId == SCENE_INISIE_R && flagType != FLAG_CYCL_SCENE_COLLECTIBLE) {
+    if (!(sceneId == SCENE_INISIE_R && flagType == FLAG_CYCL_SCENE_COLLECTIBLE)) {
         sceneId = Play_GetOriginalSceneId(sceneId);
     }
 

--- a/mm/2s2h/Rando/StaticData/Checks.cpp
+++ b/mm/2s2h/Rando/StaticData/Checks.cpp
@@ -211,15 +211,15 @@ std::map<RandoCheckId, RandoStaticCheck> Checks = {
     RC(RC_STONE_TOWER_TEMPLE_ENTRANCE_CHEST,                    RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x16,                                                                RI_STONE_TOWER_STRAY_FAIRY),
     RC(RC_STONE_TOWER_TEMPLE_ENTRANCE_SWITCH_CHEST,             RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x12,                                                                RI_STONE_TOWER_STRAY_FAIRY),
     RC(RC_STONE_TOWER_TEMPLE_INVERTED_BOSS_HC,                  RCTYPE_FREESTANDING,     SCENE_INISIE_BS,                FLAG_CYCL_SCENE_COLLECTIBLE, 0x1f,                                                                RI_HEART_CONTAINER),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_BOSS_KEY,                 RCTYPE_CHEST,            SCENE_INISIE_R,                 FLAG_CYCL_SCENE_CHEST,       0x1e,                                                                RI_STONE_TOWER_BOSS_KEY),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_BOSS_KEY,                 RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x1e,                                                                RI_STONE_TOWER_BOSS_KEY),
     RC(RC_STONE_TOWER_TEMPLE_INVERTED_BOSS_WARP,                RCTYPE_FREESTANDING,     SCENE_INISIE_BS,                FLAG_NONE,                   0x00,                                                                RI_REMAINS_TWINMOLD),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_DEATH_ARMOS_CHEST,        RCTYPE_CHEST,            SCENE_INISIE_R,                 FLAG_CYCL_SCENE_CHEST,       0x05,                                                                RI_STONE_TOWER_SMALL_KEY),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_EAST_LOWER_CHEST,         RCTYPE_CHEST,            SCENE_INISIE_R,                 FLAG_CYCL_SCENE_CHEST,       0x13,                                                                RI_STONE_TOWER_STRAY_FAIRY),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_EAST_MIDDLE_CHEST,        RCTYPE_CHEST,            SCENE_INISIE_R,                 FLAG_CYCL_SCENE_CHEST,       0x04,                                                                RI_STONE_TOWER_SMALL_KEY),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_EAST_UPPER_CHEST,         RCTYPE_CHEST,            SCENE_INISIE_R,                 FLAG_CYCL_SCENE_CHEST,       0x0e,                                                                RI_STONE_TOWER_STRAY_FAIRY),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_ENTRANCE_CHEST,           RCTYPE_CHEST,            SCENE_INISIE_R,                 FLAG_CYCL_SCENE_CHEST,       0x10,                                                                RI_STONE_TOWER_STRAY_FAIRY),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_GIANT_MASK,               RCTYPE_CHEST,            SCENE_INISIE_R,                 FLAG_CYCL_SCENE_CHEST,       0x1a,                                                                RI_MASK_GIANT),
-    RC(RC_STONE_TOWER_TEMPLE_INVERTED_WIZZROBE_CHEST,           RCTYPE_CHEST,            SCENE_INISIE_R,                 FLAG_CYCL_SCENE_CHEST,       0x11,                                                                RI_STONE_TOWER_STRAY_FAIRY),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_DEATH_ARMOS_CHEST,        RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x05,                                                                RI_STONE_TOWER_SMALL_KEY),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_EAST_LOWER_CHEST,         RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x13,                                                                RI_STONE_TOWER_STRAY_FAIRY),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_EAST_MIDDLE_CHEST,        RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x04,                                                                RI_STONE_TOWER_SMALL_KEY),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_EAST_UPPER_CHEST,         RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x0e,                                                                RI_STONE_TOWER_STRAY_FAIRY),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_ENTRANCE_CHEST,           RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x10,                                                                RI_STONE_TOWER_STRAY_FAIRY),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_GIANT_MASK,               RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x1a,                                                                RI_MASK_GIANT),
+    RC(RC_STONE_TOWER_TEMPLE_INVERTED_WIZZROBE_CHEST,           RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x11,                                                                RI_STONE_TOWER_STRAY_FAIRY),
     RC(RC_STONE_TOWER_TEMPLE_LIGHT_ARROW,                       RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x1b,                                                                RI_ARROW_LIGHT),
     RC(RC_STONE_TOWER_TEMPLE_MAP,                               RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x1d,                                                                RI_STONE_TOWER_MAP),
     RC(RC_STONE_TOWER_TEMPLE_MIRRORS_ROOM_CENTER_CHEST,         RCTYPE_CHEST,            SCENE_INISIE_N,                 FLAG_CYCL_SCENE_CHEST,       0x0f,                                                                RI_STONE_TOWER_STRAY_FAIRY),
@@ -862,9 +862,7 @@ std::map<RandoCheckId, RandoStaticCheck> Checks = {
 // should keep an eye on performance, because this is used in various draw calls. One possible optimization is to create
 // a hash map from the list of checks but that seems overkill for now.
 RandoStaticCheck GetCheckFromFlag(FlagType flagType, s32 flag, s16 sceneId) {
-    if (sceneId != SCENE_INISIE_R) {
-        sceneId = Play_GetOriginalSceneId(sceneId);
-    }
+    sceneId = Play_GetOriginalSceneId(sceneId);
 
     for (auto& [check, data] : Checks) {
         if (data.flagType == flagType && data.flag == flag && (sceneId == SCENE_MAX || data.sceneId == sceneId)) {

--- a/mm/2s2h/Rando/StaticData/StaticData.h
+++ b/mm/2s2h/Rando/StaticData/StaticData.h
@@ -27,7 +27,6 @@ struct RandoStaticCheck {
 extern std::map<RandoCheckId, RandoStaticCheck> Checks;
 
 RandoStaticCheck GetCheckFromFlag(FlagType flagType, s32 flag, s16 sceneId = SCENE_MAX);
-RandoStaticCheck GetCheckForPot(s32 flag, s16 sceneId = SCENE_MAX);
 RandoCheckId GetCheckIdFromName(const char* name);
 
 struct RandoStaticItem {

--- a/mm/2s2h/Rando/StaticData/StaticData.h
+++ b/mm/2s2h/Rando/StaticData/StaticData.h
@@ -27,6 +27,7 @@ struct RandoStaticCheck {
 extern std::map<RandoCheckId, RandoStaticCheck> Checks;
 
 RandoStaticCheck GetCheckFromFlag(FlagType flagType, s32 flag, s16 sceneId = SCENE_MAX);
+RandoStaticCheck GetCheckForPot(s32 flag, s16 sceneId = SCENE_MAX);
 RandoCheckId GetCheckIdFromName(const char* name);
 
 struct RandoStaticItem {


### PR DESCRIPTION
This updates the exception for Inverted Stone Tower's sceneId getting converted (hopefully to allow upside down chests to work). Looking at `Play_SaveCycleSceneFlags()`, only the `collectible` and `clearedRoom` flags are saved to Inverted, while the rest are saved to Normal Stone Tower Temple. I haven't retested every check, but the ones I checked in both scenes are still working. 

Additionally, I made some changes to pots that I think resolve the issues I was seeing in STT. At some point we should probably go through and double check all of the pots in other scenes that convert with `Play_GetOriginalSceneId()` to ensure there aren't any other issues. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2300466518.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2300484458.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2300581603.zip)
<!--- section:artifacts:end -->