### PR TITLE
Added ranch checks to glitchless logic

### DIFF
--- a/mm/2s2h/Rando/Logic/Regions.cpp
+++ b/mm/2s2h/Rando/Logic/Regions.cpp
@@ -1216,6 +1216,11 @@ std::unordered_map<RandoRegionId, RandoRegion> Regions = {
         },
     } },
     { RR_RANCH_BARN, RandoRegion{ .sceneId = SCENE_OMOYA,
+        .checks = {
+            CHECK(RC_ROMANI_RANCH_BARN_COW_LEFT, CAN_PLAY_SONG(EPONA) && CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG)),
+            CHECK(RC_ROMANI_RANCH_BARN_COW_MIDDLE, CAN_PLAY_SONG(EPONA) && CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG)),
+            CHECK(RC_ROMANI_RANCH_BARN_COW_RIGHT, CAN_PLAY_SONG(EPONA) && CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG))
+        },
         .exits = { //     TO                                         FROM
             EXIT(ENTRANCE(ROMANI_RANCH, 2),                 ENTRANCE(RANCH_HOUSE, 0), true),
         },
@@ -1276,7 +1281,11 @@ std::unordered_map<RandoRegionId, RandoRegion> Regions = {
     } },
     { RR_ROMANI_RANCH, RandoRegion{ .sceneId = SCENE_F01,
         .checks = {
+            // TODO : Alien reward check
             CHECK(RC_ROMANI_RANCH_EPONAS_SONG, CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG)),
+            CHECK(RC_ROMANI_RANCH_FIELD_COW_ENTRANCE, CAN_PLAY_SONG(EPONA) && CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG)),
+            CHECK(RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_BACK, CAN_PLAY_SONG(EPONA) && CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG)),
+            CHECK(RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_FRONT, CAN_PLAY_SONG(EPONA) && CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG))
         },
         .exits = { //     TO                                         FROM
             EXIT(ENTRANCE(MILK_ROAD, 1),                    ENTRANCE(ROMANI_RANCH, 0), true),

--- a/mm/2s2h/Rando/Logic/Regions.cpp
+++ b/mm/2s2h/Rando/Logic/Regions.cpp
@@ -476,6 +476,10 @@ std::unordered_map<RandoRegionId, RandoRegion> Regions = {
         },
     } },
     { RR_GORMAN_TRACK, RandoRegion{ .sceneId = SCENE_KOEPONARACE,
+        .checks = {
+            // TODO : Uncomment this out once the Alien section is implemented.
+            //CHECK(RC_CREMIA_ESCORT, CHECK_WEEKEVENTREG(WEEKEVENTREG_DEFENDED_AGAINST_THEM))
+        },
         .exits = { //     TO                                         FROM
             EXIT(ENTRANCE(MILK_ROAD, 2),                    ENTRANCE(GORMAN_TRACK, 3), CAN_PLAY_SONG(EPONA)),
             EXIT(ENTRANCE(MILK_ROAD, 3),                    ENTRANCE(GORMAN_TRACK, 0), true),


### PR DESCRIPTION
A smaller PR just to add the cow checks in logic. Not required for MVP so no biggie if this remains open for a bit.

Also added a stub for the Cremia Escort quest, but since that relies on fighting off the Aliens(which has not been implemented in No logic yet) I left it commented out.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2325317594.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2325350082.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2325423534.zip)
<!--- section:artifacts:end -->