### PR TITLE
Add Woodfall raising skip

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
@@ -1,0 +1,48 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/CustomItem/CustomItem.h"
+#include "2s2h/Rando/Rando.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+#include "functions.h"
+}
+
+#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterSkipRaisingWoodfall() {
+
+    // Forced on for rando for now.
+
+    COND_VB_SHOULD(VB_START_CUTSCENE, CVAR || IS_RANDO, {
+        s16* csId = va_arg(args, s16*);
+        if (gPlayState->sceneId == SCENE_21MITURINMAE) {
+            if (*csId == 11) {
+                *should = false;
+
+                // Need to reload the scene after WEEKEVENTREG_12_20 gets set for the temple to be up.
+                // Based on WarpPoint.cpp
+                Player* player = GET_PLAYER(gPlayState);
+
+                gPlayState->nextEntrance = ENTRANCE(WOODFALL, 0);
+                gPlayState->transitionTrigger = TRANS_TRIGGER_START;
+                gPlayState->transitionType = TRANS_TYPE_INSTANT;
+
+                gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance = ENTRANCE(WOODFALL, 0);
+                gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = 0;
+                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.x = player->actor.world.pos.x;
+                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.y = player->actor.world.pos.y;
+                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.z = player->actor.world.pos.z;
+                gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = player->actor.shape.rot.y;
+                gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D);
+                gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
+                gSaveContext.respawnFlag = -8;
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSkipRaisingWoodfall, { CVAR_NAME, "IS_RANDO" });

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
@@ -14,10 +14,7 @@ extern "C" {
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipRaisingWoodfall() {
-
-    // Forced on for rando for now.
-
-    COND_VB_SHOULD(VB_START_CUTSCENE, CVAR || IS_RANDO, {
+    COND_VB_SHOULD(VB_START_CUTSCENE, CVAR, {
         s16* csId = va_arg(args, s16*);
         if (gPlayState->sceneId == SCENE_21MITURINMAE) {
             if (*csId == 11) {
@@ -45,4 +42,4 @@ void RegisterSkipRaisingWoodfall() {
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterSkipRaisingWoodfall, { CVAR_NAME, "IS_RANDO" });
+static RegisterShipInitFunc initFunc(RegisterSkipRaisingWoodfall, { CVAR_NAME });


### PR DESCRIPTION
Went with a Story Cutscene for this, but I'm not super attached to that. 

Without the cutscene, the scene needs to be reloaded for the temple to show up, so I have the player "warp" to their current location. I'm not sure about how much I like the transition, but it seems to be working. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2350288956.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2350294175.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2350305082.zip)
<!--- section:artifacts:end -->