### PR TITLE
skip giants stopping moon cs

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
@@ -14,8 +14,7 @@ extern "C" {
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipStoppingMoon() {
-    // Forced on for rando for now
-    COND_VB_SHOULD(VB_START_CUTSCENE, CVAR || IS_RANDO, {
+    COND_VB_SHOULD(VB_START_CUTSCENE, CVAR, {
         s16* csId = va_arg(args, s16*);
         if (gPlayState->sceneId == SCENE_OKUJOU) {
             if (*csId == 12) {
@@ -36,4 +35,4 @@ void RegisterSkipStoppingMoon() {
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterSkipStoppingMoon, { CVAR_NAME, "IS_RANDO" });
+static RegisterShipInitFunc initFunc(RegisterSkipStoppingMoon, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
@@ -1,0 +1,39 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/CustomItem/CustomItem.h"
+#include "2s2h/Rando/Rando.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+#include "functions.h"
+}
+
+#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterSkipStoppingMoon() {
+    // Forced on for rando for now
+    COND_VB_SHOULD(VB_START_CUTSCENE, CVAR || IS_RANDO, {
+        s16* csId = va_arg(args, s16*);
+        if (gPlayState->sceneId == SCENE_OKUJOU) {
+            if (*csId == 12) {
+                if (CHECK_QUEST_ITEM(QUEST_REMAINS_ODOLWA) && CHECK_QUEST_ITEM(QUEST_REMAINS_GOHT) &&
+                    CHECK_QUEST_ITEM(QUEST_REMAINS_GYORG) && CHECK_QUEST_ITEM(QUEST_REMAINS_TWINMOLD)) {
+                    *should = false;
+                    GameInteractor::Instance->events.emplace_back(GIEventTransition{
+                        .entrance = ENTRANCE(THE_MOON, 0),
+                        .cutsceneIndex = 0,
+                        .transitionTrigger = TRANS_TRIGGER_START,
+                        .transitionType = TRANS_TYPE_INSTANT,
+                    });
+                    SET_WEEKEVENTREG(WEEKEVENTREG_25_02); // giants called to tower
+                    SET_WEEKEVENTREG(WEEKEVENTREG_93_04); // watched giants stopping moon cs (persistant)
+                }
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSkipStoppingMoon, { CVAR_NAME, "IS_RANDO" });


### PR DESCRIPTION
Skips the cutscene(s) of the giants coming to stop the moon if the player has all 4 remains after playing Oath.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2352223327.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2352223415.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2352227546.zip)
<!--- section:artifacts:end -->