### PR TITLE
Add Respawn Event

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
@@ -21,22 +21,15 @@ void RegisterSkipRaisingWoodfall() {
                 *should = false;
 
                 // Need to reload the scene after WEEKEVENTREG_12_20 gets set for the temple to be up.
-                // Based on WarpPoint.cpp
                 Player* player = GET_PLAYER(gPlayState);
-
-                gPlayState->nextEntrance = ENTRANCE(WOODFALL, 0);
-                gPlayState->transitionTrigger = TRANS_TRIGGER_START;
-                gPlayState->transitionType = TRANS_TYPE_INSTANT;
-
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance = ENTRANCE(WOODFALL, 0);
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = 0;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.x = player->actor.world.pos.x;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.y = player->actor.world.pos.y;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.z = player->actor.world.pos.z;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = player->actor.shape.rot.y;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D);
-                gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
-                gSaveContext.respawnFlag = -8;
+                GameInteractor::Instance->events.emplace_back(GIEventRespawn{
+                    .entrance = gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance,
+                    .roomIndex = gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex,
+                    .posX = player->actor.world.pos.x,
+                    .posY = player->actor.world.pos.y,
+                    .posZ = player->actor.world.pos.z,
+                    .yaw = player->actor.shape.rot.y,
+                });
             }
         }
     });

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
@@ -22,23 +22,14 @@ void RegisterSkipWakingAndRidingTurtle() {
                 *should = false;
 
                 // Need to reload scene. Position is where Link ends up after CS
-                // Differences from no skip: Camera ends up behind Link, Lulu is gone
-                // Based on WarpPoint.cpp
-                Player* player = GET_PLAYER(gPlayState);
-
-                gPlayState->nextEntrance = ENTRANCE(ZORA_CAPE, 2);
-                gPlayState->transitionTrigger = TRANS_TRIGGER_START;
-                gPlayState->transitionType = TRANS_TYPE_INSTANT;
-
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance = ENTRANCE(ZORA_CAPE, 2);
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = 0;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.x = -5525.0f;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.y = 14.0f;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.z = 1548.0f;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = -16384;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D);
-                gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
-                gSaveContext.respawnFlag = -8;
+                GameInteractor::Instance->events.emplace_back(GIEventRespawn{
+                    .entrance = gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance,
+                    .roomIndex = gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex,
+                    .posX = -5525.0f,
+                    .posY = 14.0f,
+                    .posZ = 1548.0f,
+                    .yaw = -16384,
+                });
             }
             // 13 is turtle leaving zora cape first time, 15 is subsequent times
             if (*csId == 13 || *csId == 15) {

--- a/mm/2s2h/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/GameInteractor/GameInteractor.cpp
@@ -436,7 +436,20 @@ void ProcessEvents(Actor* actor) {
         gPlayState->transitionTrigger = e->transitionTrigger;
         gPlayState->transitionType = e->transitionType;
         GameInteractor::Instance->currentEvent = GIEventNone{};
-    } else if (auto e = std::get_if<GIEventSpawnActor>(&nextEvent)) {
+    } else if (auto e = std::get_if<GIEventRespawn>(&nextEvent)) {
+        gPlayState->nextEntrance = gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance;
+        gPlayState->transitionTrigger = TRANS_TRIGGER_START;
+        gPlayState->transitionType = TRANS_TYPE_INSTANT;
+        gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.x = e->posX;
+        gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.y = e->posY;
+        gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.z = e->posZ;
+        gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = e->yaw;
+        gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D);
+        gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
+        gSaveContext.respawnFlag = -8;
+        GameInteractor::Instance->currentEvent = GIEventNone{};
+    }  
+    else if (auto e = std::get_if<GIEventSpawnActor>(&nextEvent)) {
         // if true, the coordinates are made relative to the player's position and rotation, 0 rotation is facing the
         // same direction as the player, x+ is to the players right, y+ is up, z+ is in front of the player
         if (e->relativeCoords) {

--- a/mm/2s2h/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/GameInteractor/GameInteractor.cpp
@@ -437,13 +437,12 @@ void ProcessEvents(Actor* actor) {
         gPlayState->transitionType = e->transitionType;
         GameInteractor::Instance->currentEvent = GIEventNone{};
     } else if (auto e = std::get_if<GIEventRespawn>(&nextEvent)) {
-        // Only trigger if currently in the entrance/room where the event was triggered.
+        // Only trigger if currently in the entrance/room associated to event
         if (gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance == e->entrance &&
             gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex == e->roomIndex) {
             gPlayState->nextEntrance = gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance;
             gPlayState->transitionTrigger = TRANS_TRIGGER_START;
             gPlayState->transitionType = TRANS_TYPE_INSTANT;
-            // gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex
             gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.x = e->posX;
             gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.y = e->posY;
             gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.z = e->posZ;

--- a/mm/2s2h/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/GameInteractor/GameInteractor.cpp
@@ -437,19 +437,23 @@ void ProcessEvents(Actor* actor) {
         gPlayState->transitionType = e->transitionType;
         GameInteractor::Instance->currentEvent = GIEventNone{};
     } else if (auto e = std::get_if<GIEventRespawn>(&nextEvent)) {
-        gPlayState->nextEntrance = gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance;
-        gPlayState->transitionTrigger = TRANS_TRIGGER_START;
-        gPlayState->transitionType = TRANS_TYPE_INSTANT;
-        gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.x = e->posX;
-        gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.y = e->posY;
-        gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.z = e->posZ;
-        gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = e->yaw;
-        gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D);
-        gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
-        gSaveContext.respawnFlag = -8;
+        // Only trigger if currently in the entrance/room where the event was triggered.
+        if (gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance == e->entrance &&
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex == e->roomIndex) {
+            gPlayState->nextEntrance = gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance;
+            gPlayState->transitionTrigger = TRANS_TRIGGER_START;
+            gPlayState->transitionType = TRANS_TYPE_INSTANT;
+            // gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.x = e->posX;
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.y = e->posY;
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.z = e->posZ;
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = e->yaw;
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D);
+            gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
+            gSaveContext.respawnFlag = -8;
+        }
         GameInteractor::Instance->currentEvent = GIEventNone{};
-    }  
-    else if (auto e = std::get_if<GIEventSpawnActor>(&nextEvent)) {
+    } else if (auto e = std::get_if<GIEventSpawnActor>(&nextEvent)) {
         // if true, the coordinates are made relative to the player's position and rotation, 0 rotation is facing the
         // same direction as the player, x+ is to the players right, y+ is up, z+ is in front of the player
         if (e->relativeCoords) {

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -245,13 +245,15 @@ struct GIEventTransition {
 };
 
 struct GIEventRespawn {
+    u16 entrance;
+    u8 roomIndex;
     f32 posX;
     f32 posY;
     f32 posZ;
     s16 yaw;
 };
 
-typedef std::variant<GIEventNone, GIEventGiveItem, GIEventSpawnActor, GIEventTransition> GIEvent;
+typedef std::variant<GIEventNone, GIEventGiveItem, GIEventSpawnActor, GIEventTransition, GIEventRespawn> GIEvent;
 
 class GameInteractor {
   public:

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -244,6 +244,13 @@ struct GIEventTransition {
     u8 transitionType;
 };
 
+struct GIEventRespawn {
+    f32 posX;
+    f32 posY;
+    f32 posZ;
+    s16 yaw;
+};
+
 typedef std::variant<GIEventNone, GIEventGiveItem, GIEventSpawnActor, GIEventTransition> GIEvent;
 
 class GameInteractor {


### PR DESCRIPTION
This adds a new GIEvent for respawning and converts the woodfall and turtle raising skips to use the event queue instead of copy/pasting the warp code. 

It works for the skips because in the `VB_START_CUTSCENE`, `*should` is set to false and the player isn't put in a cutscene state. 

To prevent respawing unintendedly, the event is queued up with an intended entrance/room. When the event is executed, it will check if the intended entrance/room match the current entrance/room. If they don't match, the event will just be removed.

I did some testing by queueing some Respawns and Item Gives right during a scene transition, and the Item GIves executed, while the Respawns did not. 

Leaving as a Draft for now because there's an issue with the Turtle Wake skip if Item Get Animations are not skipped with this approach. Also not sure if you'd want the scene reloading functionality handled differently. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2357489025.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2357495743.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2357497528.zip)
<!--- section:artifacts:end -->