### PR TITLE
Fix Kamaro check

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnYb.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnYb.cpp
@@ -14,7 +14,7 @@ void Rando::ActorBehavior::InitEnYbBehavior() {
      * checks if you have Kamaro's Mask in your inventory before marking his quest as complete. Normally, this is always
      * true, making the check redundant. For randomizer, we wrap that check.
      */
-    COND_VB_SHOULD(VB_HAVE_KAMAROS_MASK, IS_RANDO, { *should = !RANDO_SAVE_CHECKS[RC_TERMINA_FIELD_KAMARO].obtained; });
+    COND_VB_SHOULD(VB_HAVE_KAMAROS_MASK, IS_RANDO, { *should = RANDO_SAVE_CHECKS[RC_TERMINA_FIELD_KAMARO].eligible; });
 
     COND_VB_SHOULD(VB_GIVE_ITEM_FROM_OFFER, IS_RANDO, {
         GetItemId* item = va_arg(args, GetItemId*);


### PR DESCRIPTION
I had goofed on Kamaro, resulting in his check always being granted upon talking to him. This fixes that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2370295615.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2370300376.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2370314280.zip)
<!--- section:artifacts:end -->