### PR TITLE
Fix crash with Curiosity Shop owner checks

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnFsn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnFsn.cpp
@@ -15,27 +15,31 @@ void Rando::ActorBehavior::InitEnFsnBehavior() {
         Actor* actor = va_arg(args, Actor*);
         if (actor->id == ACTOR_EN_FSN) { // Curiosity Shop owner
             EnFsn* enFsn = (EnFsn*)actor;
-            EnGirlA* enGirlA = enFsn->items[enFsn->cursorIndex];
-            RandoCheckId randoCheckId = (RandoCheckId)enGirlA->actor.world.rot.z;
-            // Only handle the two special checks. Leave stolen items and actor purchases as-is.
-            if (enFsn->isSelling && (randoCheckId == RC_CURIOSITY_SHOP_SPECIAL_ITEM ||
-                                     randoCheckId == RC_BOMB_SHOP_ITEM_OR_CURIOSITY_SHOP_ITEM)) {
-                *should = false;
-                Player* player = GET_PLAYER(gPlayState);
-                player->talkActor = actor;
-                player->talkActorDistance = actor->xzDistToPlayer;
-                Player_TalkWithPlayer(gPlayState, actor);
-                actor->flags |= ACTOR_FLAG_TALK_REQUESTED;
-                enFsn->actionFunc = EnFsn_ResumeInteraction;
-                enGirlA->buyFunc(gPlayState, enGirlA);
-                /*
-                 * This notebook event must be faked because the randomized item probably won't be the All-Night Mask.
-                 * There exists a minor bug where, if the player tries to sell something immediately after buying
-                 * the special item, this notebook event will pop as Link pulls out the item to show. The Curiosity
-                 * Shop owner's response will then erase that textbox. Not game breaking, but something to note.
-                 */
-                if (randoCheckId == RC_CURIOSITY_SHOP_SPECIAL_ITEM) {
-                    Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_RECEIVED_ALL_NIGHT_MASK);
+            // Handling for when the Curiosity Shop owner sells something to the player
+            if (enFsn->isSelling && enFsn->cursorIndex >= 0 && enFsn->cursorIndex <= 2) {
+                EnGirlA* enGirlA = enFsn->items[enFsn->cursorIndex];
+                RandoCheckId randoCheckId = (RandoCheckId)enGirlA->actor.world.rot.z;
+                // Only handle the two special checks. Leave stolen items as-is.
+                if (randoCheckId == RC_CURIOSITY_SHOP_SPECIAL_ITEM ||
+                    randoCheckId == RC_BOMB_SHOP_ITEM_OR_CURIOSITY_SHOP_ITEM) {
+                    *should = false;
+                    Player* player = GET_PLAYER(gPlayState);
+                    player->talkActor = actor;
+                    player->talkActorDistance = actor->xzDistToPlayer;
+                    Player_TalkWithPlayer(gPlayState, actor);
+                    actor->flags |= ACTOR_FLAG_TALK_REQUESTED;
+                    enFsn->actionFunc = EnFsn_ResumeInteraction;
+                    enGirlA->buyFunc(gPlayState, enGirlA);
+                    /*
+                     * This notebook event must be faked because the randomized item probably won't be the All-Night
+                     * Mask. There exists a minor bug where, if the player tries to sell something immediately after
+                     * buying the special item, this notebook event will pop as Link pulls out the item to show. The
+                     * Curiosity Shop owner's response will then erase that textbox. Not game breaking, but something to
+                     * note.
+                     */
+                    if (randoCheckId == RC_CURIOSITY_SHOP_SPECIAL_ITEM) {
+                        Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_RECEIVED_ALL_NIGHT_MASK);
+                    }
                 }
             }
         }


### PR DESCRIPTION
#103 mistakenly assumed that the only Curiosity Shop owner checks were from when he sells to the player. This led to a crash when receiving items from him in the back of the Curiosity Shop because the actor tried to access its `items` array before verifying that it was selling. This PR fixes that to check that the actor is selling before accessing `items`.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2374372683.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2374379937.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2374427238.zip)
<!--- section:artifacts:end -->