### PR TITLE
Fix bug with Igos and lackey enemies spawning during credits

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBossCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBossCutscenes.cpp
@@ -32,7 +32,12 @@ void RegisterSkipBossCutscenes() {
     COND_ID_HOOK(ShouldActorInit, ACTOR_BOSS_02, CVAR, [](Actor* actor, bool* should) { SET_EVENTINF(EVENTINF_55); });
 
     // Igos du Ikana (and lackeys) intro
-    COND_ID_HOOK(ShouldActorInit, ACTOR_EN_KNIGHT, CVAR, [](Actor* actor, bool* should) { SET_EVENTINF(EVENTINF_57); });
+    COND_ID_HOOK(ShouldActorInit, ACTOR_EN_KNIGHT, CVAR, [](Actor* actor, bool* should) {
+        // In the credits, this sceneLayer will 1. Do not set this flag in that case, or things will break.
+        if (gSaveContext.sceneLayer == 0) {
+            SET_EVENTINF(EVENTINF_57);
+        }
+    });
 
     COND_VB_SHOULD(VB_START_CUTSCENE, CVAR, {
         s16* csId = va_arg(args, s16*);


### PR DESCRIPTION
Igos du Ikana's Lair is visited during credits. If the boss intro flag is set (as per the skip), enemies will spawn and break the credits. `gSaveContext.sceneLayer` is 0 here in normal gameplay and 1 during the credits. Only set this flag in normal gameplay.

This can be tested with Stage 0 in the debug menu.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2379380807.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2379391318.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2379419454.zip)
<!--- section:artifacts:end -->