### PR TITLE
fix milk bar crash

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnToto.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnToto.cpp
@@ -4,6 +4,7 @@
 extern "C" {
 #include "variables.h"
 #include "src/overlays/actors/ovl_En_Fu/z_en_fu.h"
+#include "src/overlays/actors/ovl_En_Toto/z_en_toto.h"
 void Player_TalkWithPlayer(PlayState* play, Actor* actor);
 }
 
@@ -12,6 +13,7 @@ void Rando::ActorBehavior::InitEnTotoBehavior() {
         GetItemId* item = va_arg(args, GetItemId*);
         Actor* refActor = va_arg(args, Actor*);
         Player* player = GET_PLAYER(gPlayState);
+        EnToto* enToto = (EnToto*)refActor;
 
         if (refActor->id != ACTOR_EN_TOTO) {
             return;
@@ -25,5 +27,9 @@ void Rando::ActorBehavior::InitEnTotoBehavior() {
         player->talkActorDistance = refActor->xzDistToPlayer;
         player->exchangeItemAction = PLAYER_IA_MINUS1;
         Player_TalkWithPlayer(gPlayState, refActor);
+        // The following values get into a weird state because of the rando process, so set them to safe values
+        enToto->actionFuncIndex = 0;
+        enToto->text->unk0 = 0;
+        enToto->text->unk1 = 0;
     });
 }

--- a/mm/2s2h/Rando/ActorBehavior/EnToto.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnToto.cpp
@@ -4,8 +4,6 @@
 extern "C" {
 #include "variables.h"
 #include "src/overlays/actors/ovl_En_Fu/z_en_fu.h"
-#include "src/overlays/actors/ovl_En_Toto/z_en_toto.h"
-void Player_TalkWithPlayer(PlayState* play, Actor* actor);
 }
 
 void Rando::ActorBehavior::InitEnTotoBehavior() {
@@ -13,7 +11,6 @@ void Rando::ActorBehavior::InitEnTotoBehavior() {
         GetItemId* item = va_arg(args, GetItemId*);
         Actor* refActor = va_arg(args, Actor*);
         Player* player = GET_PLAYER(gPlayState);
-        EnToto* enToto = (EnToto*)refActor;
 
         if (refActor->id != ACTOR_EN_TOTO) {
             return;
@@ -26,10 +23,5 @@ void Rando::ActorBehavior::InitEnTotoBehavior() {
         player->talkActor = refActor;
         player->talkActorDistance = refActor->xzDistToPlayer;
         player->exchangeItemAction = PLAYER_IA_MINUS1;
-        Player_TalkWithPlayer(gPlayState, refActor);
-        // The following values get into a weird state because of the rando process, so set them to safe values
-        enToto->actionFuncIndex = 0;
-        enToto->text->unk0 = 0;
-        enToto->text->unk1 = 0;
     });
 }


### PR DESCRIPTION
This prevents the crash by setting some values on EnToto to 0. I think only unk1 is needed to be set here, but setting all three should be safe. I was getting the crash with goron and deku, didn't test others. Now all should be working with/without GI CS skips. 

Part of the problem is centered around 
```
s32 func_80BA4C44(EnToto* this, PlayState* play) {
    s32 ret;

    ret = D_80BA5174[this->text->unk0](this, play);
    if (ret != 0) {
        this->text += ret;
        return func_80BA4C0C(this, play);
    }
    return 0;
}
```

`ret` is initially garbage (which is why the crash might have been platform dependent). if `D_80BA5174[this->text->unk0]` goes out of bounds (in this case it was a value of 17 going 1 index over) an unintended function is run. In our situation, the unintended function didn't have a return, so `ret` remained garbage, which ultimately led to other issues. 

It seemed to me that `text->unk1` is used to set the `actionFuncIndex` at times, and the combination of unk0, unk1, and the actionFuncIndex is not set right when we do the VB_GIVE_ITEM_FROM_OFFER skip. I'm also not sure how the Skip Get Item Cutscenes were involved. 

My analysis isn't very good/complete, but `z_en_toto.c` is weird.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2388653200.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2388660808.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2388661798.zip)
<!--- section:artifacts:end -->