### PR TITLE
Fix Anju Stock Pot Inn check softlocks

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
@@ -37,6 +37,7 @@ void Rando::ActorBehavior::OnFileLoad() {
     Rando::ActorBehavior::InitDmStkBehavior();
     Rando::ActorBehavior::InitDoorWarp1VBehavior();
     Rando::ActorBehavior::InitEnAkindonutsBehavior();
+    Rando::ActorBehavior::InitEnAnBehavior();
     Rando::ActorBehavior::InitEnAob01Behavior();
     Rando::ActorBehavior::InitEnBabaBehavior();
     Rando::ActorBehavior::InitEnBalBehavior();

--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.h
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.h
@@ -15,6 +15,7 @@ void InitDmHinaBehavior();
 void InitDmStkBehavior();
 void InitDoorWarp1VBehavior();
 void InitEnAkindonutsBehavior();
+void InitEnAnBehavior();
 void InitEnAob01Behavior();
 void InitEnBabaBehavior();
 void InitEnBalBehavior();

--- a/mm/2s2h/Rando/ActorBehavior/EnAn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAn.cpp
@@ -1,0 +1,46 @@
+#include "ActorBehavior.h"
+#include <libultraship/libultraship.h>
+
+extern "C" {
+#include "variables.h"
+void func_80837B60(PlayState* play, Player* player);
+s32 func_80832558(PlayState* play, Player* player, PlayerFuncD58 arg2);
+}
+
+void Rando::ActorBehavior::InitEnAnBehavior() {
+    COND_VB_SHOULD(VB_EXEC_MSG_EVENT, IS_RANDO, {
+        u32 cmdId = va_arg(args, u32);
+        Actor* actor = va_arg(args, Actor*);
+        if (actor->id == ACTOR_EN_AN) { // Anju
+            MsgScript* script = va_arg(args, MsgScript*);
+            Player* player = GET_PLAYER(gPlayState);
+            static std::vector<u8> skipCmds = {};
+
+            if (cmdId == MSCRIPT_CMD_06) { // MSCRIPT_OFFER_ITEM
+                func_80832558(gPlayState, player, func_80837B60);
+                player->talkActor = actor;
+                *should = false;
+                skipCmds.clear();
+                skipCmds.push_back(MSCRIPT_CMD_12); // Have to skip this to prevent a crash
+                skipCmds.push_back(MSCRIPT_CMD_07); // And have to skip this to prevent a softlock on repeats
+                GetItemId getItemId = (GetItemId)MSCRIPT_GET_16(script, 1);
+                // If these are skipped but not manually queued, the game will crash for some reason. This does not
+                // happen with the room key check.
+                if (getItemId == GI_LETTER_TO_KAFEI) {
+                    Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_PROMISED_TO_MEET_KAFEI);
+                    Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_RECEIVED_LETTER_TO_KAFEI);
+                }
+                return;
+            }
+
+            if (skipCmds.empty()) {
+                return;
+            }
+
+            if (cmdId == skipCmds[0]) {
+                skipCmds.erase(skipCmds.begin());
+                *should = false;
+            }
+        }
+    });
+}

--- a/mm/2s2h/Rando/MiscBehavior/OfferGetItem.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OfferGetItem.cpp
@@ -23,11 +23,6 @@ void Rando::MiscBehavior::InitOfferGetItemBehavior() {
 
         if (cmdId == MSCRIPT_CMD_06) { // MSCRIPT_OFFER_ITEM
             switch (actor->id) {
-                // Anju crashes for some reason here if you don't skip the next text wait.
-                case ACTOR_EN_AN:
-                    skipCmds.clear();
-                    skipCmds.push_back(MSCRIPT_CMD_12);
-                    [[fallthrough]];
                 case ACTOR_EN_BJT:
                 case ACTOR_EN_NB:
                 case ACTOR_EN_PM:


### PR DESCRIPTION
- The softlocks occurred whenever the `WEEKEVENTREG`/Bombers' Notebook flags for these were already set (i.e. repeat cycles). I don't fully understand *why*, but skipping `MSCRIPT_CMD_07` prevents the softlock.
  - [EnGo.cpp](https://github.com/garrettjoecox/2ship2harkinian/blob/develop-rando/mm/2s2h/Rando/ActorBehavior/EnGo.cpp) does something similar with adding `MSCRIPT_CMD_07` to the skip list.
- For the Letter to Kafei check in particular, I had to manually queue both related notebook events to prevent a crash on top of the softlock fix. The room key check doesn't require the manual queue for some reason; it updates the notebook accordingly without being forced.
- Created actor behavior file for Anju since this fix makes these checks inappropriate for the general handler

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2388365756.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2388371444.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2388403165.zip)
<!--- section:artifacts:end -->