### PR TITLE
Fix Anju crash on Letter to Kafei check

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnAn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAn.cpp
@@ -18,15 +18,18 @@ void Rando::ActorBehavior::InitEnAnBehavior() {
 
             if (cmdId == MSCRIPT_CMD_06) { // MSCRIPT_OFFER_ITEM
                 func_80832558(gPlayState, player, func_80837B60);
-                player->talkActor = actor;
                 *should = false;
                 skipCmds.clear();
                 skipCmds.push_back(MSCRIPT_CMD_12); // Have to skip this to prevent a crash
                 skipCmds.push_back(MSCRIPT_CMD_07); // And have to skip this to prevent a softlock on repeats
                 GetItemId getItemId = (GetItemId)MSCRIPT_GET_16(script, 1);
-                // If these are skipped but not manually queued, the game will crash for some reason. This does not
-                // happen with the room key check.
-                if (getItemId == GI_LETTER_TO_KAFEI) {
+                /*
+                 * If the player has the Bombers' Notebook and this is the Letter to Kafei check, the game will crash
+                 * unless player->talkActor is set AND these skipped notebook events are queued. This does not happen
+                 * with the Room Key check.
+                 */
+                if (CHECK_QUEST_ITEM(QUEST_BOMBERS_NOTEBOOK) && getItemId == GI_LETTER_TO_KAFEI) {
+                    player->talkActor = actor;
                     Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_PROMISED_TO_MEET_KAFEI);
                     Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_RECEIVED_LETTER_TO_KAFEI);
                 }


### PR DESCRIPTION
#135 fixed softlocks with Anju repeat checks, but also caused a crash on the Letter to Kafei check if it was the first time AND the player did not have the Bombers' Notebook. Other combinations of repeats or having the notebook did not result in a crash. The notebook is a finicky thing here.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2390954532.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2390971724.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2391033210.zip)
<!--- section:artifacts:end -->