### PR TITLE
Sparkles on RI_NONE and Progressive Magic

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
@@ -43,7 +43,7 @@ void EnGirlA_RandoDrawFunc(Actor* actor, PlayState* play) {
 
     Matrix_RotateYS(enGirlA->rotY, MTXMODE_APPLY);
 
-    Rando::DrawItem(randoSaveCheck.randoItemId);
+    Rando::DrawItem(randoSaveCheck.randoItemId, actor);
 }
 
 void EnGirlA_RandoBought(PlayState* play, EnGirlA* enGirlA) {

--- a/mm/2s2h/Rando/ActorBehavior/EnItem00.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnItem00.cpp
@@ -86,7 +86,7 @@ void Rando::ActorBehavior::InitEnItem00Behavior() {
             [](Actor* actor, PlayState* play) {
                 auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
                 Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM));
+                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
             });
     });
 }

--- a/mm/2s2h/Rando/ActorBehavior/EnSi.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnSi.cpp
@@ -19,7 +19,7 @@ void EnSi_DrawCustom(Actor* thisx, PlayState* play) {
 
     auto randoSaveCheck = RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId];
 
-    Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, randoStaticCheck.randoCheckId));
+    Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, randoStaticCheck.randoCheckId), thisx);
 }
 
 void Rando::ActorBehavior::InitEnSiBehavior() {

--- a/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
@@ -965,7 +965,7 @@ void Rando::ActorBehavior::InitObjTsuboBehavior() {
                 auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
                 RandoItemId randoItemId = Rando::ConvertItem(randoSaveCheck.randoItemId);
                 Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM));
+                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
             });
         *should = false;
 

--- a/mm/2s2h/Rando/DrawItem.cpp
+++ b/mm/2s2h/Rando/DrawItem.cpp
@@ -272,11 +272,40 @@ void DrawBossKey(RandoItemId randoItemId) {
 
     CLOSE_DISPS(gPlayState->state.gfxCtx);
 }
+void DrawSparkles(RandoItemId randoItemId, Actor* actor) {
+    if (actor == NULL) {
+        return;
+    }
 
-void Rando::DrawItem(RandoItemId randoItemId) {
+    if (gGameState->frames % 2 == 0) {
+        return;
+    }
+
+    static Vec3f sVelocity = { 0.0f, 0.0f, 0.0f };
+    static Vec3f sAccel = { 0.0f, 0.0f, 0.0f };
+    static Color_RGBA8 sPrimColor = { 255, 255, 255, 255 };
+    static Color_RGBA8 sEnvColor = { 255, 128, 0, 255 };
+    Vec3f newPos;
+
+    newPos.x = Rand_CenteredFloat(10.0f) + actor->world.pos.x;
+    newPos.y = (Rand_ZeroOne() * 10.0f) + actor->world.pos.y;
+    newPos.z = Rand_CenteredFloat(10.0f) + actor->world.pos.z;
+
+    if (actor->id == ACTOR_EN_SI) {
+        newPos.y = (Rand_ZeroOne() * 10.0f) + actor->world.pos.y - 5.0f;
+    } else if (actor->id == ACTOR_EN_ITEM00) {
+        newPos.x = Rand_CenteredFloat(20.0f) + actor->world.pos.x;
+        newPos.y = (Rand_ZeroOne() * 10.0f) + actor->world.pos.y + 10.0f;
+        newPos.z = Rand_CenteredFloat(20.0f) + actor->world.pos.z;
+    }
+
+    EffectSsKirakira_SpawnDispersed(gPlayState, &newPos, &sVelocity, &sAccel, &sPrimColor, &sEnvColor, 2000, 16);
+}
+
+void Rando::DrawItem(RandoItemId randoItemId, Actor* actor) {
     switch (randoItemId) {
         case RI_JUNK:
-            Rando::DrawItem(Rando::CurrentJunkItem());
+            Rando::DrawItem(Rando::CurrentJunkItem(), actor);
             break;
         case RI_GREAT_BAY_SMALL_KEY:
         case RI_SNOWHEAD_SMALL_KEY:
@@ -333,13 +362,24 @@ void Rando::DrawItem(RandoItemId randoItemId) {
         case RI_PROGRESSIVE_BOMB_BAG:
         case RI_PROGRESSIVE_SWORD:
         case RI_PROGRESSIVE_WALLET:
-            Rando::DrawItem(Rando::ConvertItem(randoItemId));
+            Rando::DrawItem(Rando::ConvertItem(randoItemId), actor);
             break;
         case RI_NONE:
         case RI_UNKNOWN:
             break;
         default:
             GetItem_Draw(gPlayState, Rando::StaticData::Items[randoItemId].drawId);
+            break;
+    }
+
+    switch (randoItemId) {
+        case RI_NONE:
+        case RI_PROGRESSIVE_MAGIC:
+        case RI_SINGLE_MAGIC:
+        case RI_DOUBLE_MAGIC:
+            DrawSparkles(randoItemId, actor);
+            break;
+        default:
             break;
     }
 }

--- a/mm/2s2h/Rando/Rando.h
+++ b/mm/2s2h/Rando/Rando.h
@@ -12,7 +12,7 @@
 namespace Rando {
 
 void Init();
-void DrawItem(RandoItemId randoItemId);
+void DrawItem(RandoItemId randoItemId, Actor* actor = nullptr);
 void GiveItem(RandoItemId randoItemId);
 void RemoveItem(RandoItemId randoItemId);
 RandoItemId CurrentJunkItem();


### PR DESCRIPTION
Adds Sparkles to RI_NONE and Progressive Magics to better display them on the ground.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2393815368.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2393821808.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2393849574.zip)
<!--- section:artifacts:end -->