### PR TITLE
fix riding horse after leaving gorman track scene

### DIFF
--- a/mm/2s2h/Enhancements/Minigames/SkipHorseRace.cpp
+++ b/mm/2s2h/Enhancements/Minigames/SkipHorseRace.cpp
@@ -5,6 +5,7 @@
 
 extern "C" {
 #include "functions.h"
+#include "z64horse.h"
 }
 
 #define CVAR_NAME "gEnhancements.Minigames.SkipHorseRace"
@@ -18,6 +19,7 @@ void RegisterSkipHorseRace() {
             SET_WEEKEVENTREG_HORSE_RACE_STATE(WEEKEVENTREG_HORSE_RACE_STATE_2);
             // prevent horse race start music
             gSaveContext.forcedSeqId = NA_BGM_GENERAL_SFX;
+            gHorseIsMounted = false;
         }
     });
 }


### PR DESCRIPTION
With the skip race enhancement on, starting the Horse Race on your horse then leaving the scene caused you to be put back on your horse. This fixes that issue. 

In `z_en_horse_game_check.c`, before setting the transition after the race, the following code is executed that I didn't include in the original implementation of the enhancement 

```
    gHorseIsMounted = false;
    if (player->stateFlags1 & PLAYER_STATE1_800000) {
        D_801BDAA0 = true;
    }
```

I could only include `gHorseIsMounted = false;` because gPlayState/player are null when the enhancement is executed. The issue appears to be fixed without including the `if` statement, but it's possible another edge case might come up because it's missing. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2411095177.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2411101235.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2411171231.zip)
<!--- section:artifacts:end -->