### PR TITLE
Fix postman hat softlock

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
@@ -68,6 +68,7 @@ void Rando::ActorBehavior::OnFileLoad() {
     Rando::ActorBehavior::InitEnMnkBehavior();
     Rando::ActorBehavior::InitEnOsnBehavior();
     Rando::ActorBehavior::InitEnOwlBehavior();
+    Rando::ActorBehavior::InitEnPmBehavior();
     Rando::ActorBehavior::InitEnRuppecrowBehavior();
     Rando::ActorBehavior::InitEnRzBehavior();
     Rando::ActorBehavior::InitEnSellnutsBehavior();

--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.h
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.h
@@ -46,6 +46,7 @@ void InitEnMaYtoBehavior();
 void InitEnMnkBehavior();
 void InitEnOsnBehavior();
 void InitEnOwlBehavior();
+void InitEnPmBehavior();
 void InitEnRuppecrowBehavior();
 void InitEnRzBehavior();
 void InitEnSellnutsBehavior();

--- a/mm/2s2h/Rando/ActorBehavior/EnPm.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnPm.cpp
@@ -1,0 +1,30 @@
+#include "ActorBehavior.h"
+#include <libultraship/libultraship.h>
+
+extern "C" {
+#include "variables.h"
+void func_80837B60(PlayState* play, Player* player);
+s32 func_80832558(PlayState* play, Player* player, PlayerFuncD58 arg2);
+}
+
+void Rando::ActorBehavior::InitEnPmBehavior() {
+    COND_VB_SHOULD(VB_EXEC_MSG_EVENT, IS_RANDO, {
+        u32 cmdId = va_arg(args, u32);
+        Actor* actor = va_arg(args, Actor*);
+        if (actor->id == ACTOR_EN_PM && cmdId == MSCRIPT_CMD_06) { // MSCRIPT_OFFER_ITEM from Postman
+            /*
+             * The notebook event is the very last thing that happens in the Postman script. The short of it is that,
+             * if no notebook message actually appears, the func_80832558 call will softlock since there will be no
+             * textbox close to wait on. This check is equivalent to anticipating that at least one of these two Postman
+             * notebook messages will appear at the end of this interaction.
+             */
+            if (CHECK_QUEST_ITEM(QUEST_BOMBERS_NOTEBOOK) &&
+                !(CHECK_WEEKEVENTREG(WEEKEVENTREG_BOMBERS_NOTEBOOK_EVENT_MET_POSTMAN) &&
+                  CHECK_WEEKEVENTREG(WEEKEVENTREG_BOMBERS_NOTEBOOK_EVENT_RECEIVED_POSTMANS_HAT))) {
+                Player* player = GET_PLAYER(gPlayState);
+                func_80832558(gPlayState, player, func_80837B60);
+            }
+            *should = false;
+        }
+    });
+}

--- a/mm/2s2h/Rando/MiscBehavior/OfferGetItem.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OfferGetItem.cpp
@@ -25,7 +25,6 @@ void Rando::MiscBehavior::InitOfferGetItemBehavior() {
             switch (actor->id) {
                 case ACTOR_EN_BJT:
                 case ACTOR_EN_NB:
-                case ACTOR_EN_PM:
                 case ACTOR_EN_AL:
                     func_80832558(gPlayState, player, func_80837B60);
                     *should = false;


### PR DESCRIPTION
The tl;dr is that the `func_80832558` call in the general catch-all hook would cause a softlock if no further messages appear in the script, which is possible for the Postman. I may revisit the Anju solution at some point now that I know this.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2415105392.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2415118090.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2415231931.zip)
<!--- section:artifacts:end -->