### PR TITLE
Improve Chu drops behavior

### DIFF
--- a/mm/2s2h/CustomItem/CustomItem.cpp
+++ b/mm/2s2h/CustomItem/CustomItem.cpp
@@ -96,6 +96,14 @@ void CustomItem00_Draw(Actor* actor, PlayState* play) {
     GetItem_Draw(play, CUSTOM_ITEM_PARAM);
 }
 
+// Once the item is touched we need to clear movement vars so the item doesn't sink in the players hands/above head
+void CustomItem00_ItemTouched(Actor* actor, PlayState* play) {
+    actor->speed = 0.0f;
+    actor->velocity.y = 0.0f;
+    actor->gravity = 0.0f;
+    actor->shape.yOffset = 1250.0f;
+}
+
 void CustomItem00_Update(Actor* actor, PlayState* play) {
     EnItem00* enItem00 = (EnItem00*)actor;
     Player* player = GET_PLAYER(play);
@@ -104,9 +112,7 @@ void CustomItem00_Update(Actor* actor, PlayState* play) {
         actor->shape.rot.y += 960;
     }
 
-    if (CUSTOM_ITEM_FLAGS & CustomItem::STOP_BOBBING) {
-        actor->shape.yOffset = 1250.0f;
-    } else {
+    if (!(CUSTOM_ITEM_FLAGS & CustomItem::STOP_BOBBING)) {
         actor->shape.yOffset = (Math_SinS(actor->shape.rot.y) * 150.0f) + 1250.0f;
     }
 
@@ -141,6 +147,9 @@ void CustomItem00_Update(Actor* actor, PlayState* play) {
             enItem00->unk152 = 15;
             CUSTOM_ITEM_FLAGS |= CustomItem::STOP_BOBBING;
             CUSTOM_ITEM_FLAGS |= CustomItem::KEEP_ON_PLAYER;
+            CustomItem00_ItemTouched(actor, play);
+            // Move to player right away on this frame
+            Math_Vec3f_Copy(&actor->world.pos, &GET_PLAYER(play)->actor.world.pos);
         }
 
         // If the item has been picked up
@@ -188,6 +197,7 @@ void CustomItem00_Update(Actor* actor, PlayState* play) {
                 CUSTOM_ITEM_FLAGS |= CustomItem::KEEP_ON_PLAYER;
                 // Actor_SetScale(actor, 0.0f);
                 CUSTOM_ITEM_FLAGS |= CustomItem::HIDE_TILL_OVERHEAD;
+                CustomItem00_ItemTouched(actor, play);
             }
 
             // Begin incrementing the unk152, indicating the item has been picked up

--- a/mm/2s2h/Enhancements/Equipment/ChuDrops.cpp
+++ b/mm/2s2h/Enhancements/Equipment/ChuDrops.cpp
@@ -17,19 +17,48 @@ static void ChuDrop_Give(Actor* actor, PlayState* play) {
     Item_Give(play, ITEM_BOMBCHUS_5);
 }
 
+static Color_RGBA8 sEffectPrimColor = { 255, 255, 127, 0 };
+static Color_RGBA8 sEffectEnvColor = { 255, 255, 255, 0 };
+static Vec3f sEffectVelocity = { 0.0f, 0.1f, 0.0f };
+static Vec3f sEffectAccel = { 0.0f, 0.01f, 0.0f };
+
 static void ChuDrop_Draw(Actor* actor, PlayState* play) {
     OPEN_DISPS(play->state.gfxCtx);
 
+    // Spawn sparkles like regular drops when falling.
+    // Consider promoting this to CustomItem Update itself for tossed items.
+    if ((CUSTOM_ITEM_FLAGS & CustomItem::TOSS_ON_SPAWN) && actor->gravity != 0.0f &&
+        !(actor->bgCheckFlags & (BGCHECKFLAG_GROUND | BGCHECKFLAG_GROUND_TOUCH))) {
+        if ((play->gameplayFrames & 1) == 0) {
+            Vec3f pos;
+            pos.x = actor->world.pos.x + ((Rand_ZeroOne() - 0.5f) * 10.0f);
+            pos.y = actor->world.pos.y + ((Rand_ZeroOne() - 0.5f) * 10.0f);
+            pos.z = actor->world.pos.z + ((Rand_ZeroOne() - 0.5f) * 10.0f);
+            EffectSsKirakira_SpawnSmall(play, &pos, &sEffectVelocity, &sEffectAccel, &sEffectPrimColor,
+                                        &sEffectEnvColor);
+        }
+    }
+
+    // Skip interpolation for one frame once the item is moved to the player
+    FrameInterpolation_RecordOpenChild(actor, (CUSTOM_ITEM_FLAGS & CustomItem::KEEP_ON_PLAYER) ? 1 : 0);
+    FrameInterpolation_IgnoreActorMtx();
+
     if (CVarGetInteger("gEnhancements.Graphics.3DItemDrops", 0)) {
+        CUSTOM_ITEM_FLAGS &= ~CustomItem::STOP_SPINNING;
+
         Matrix_Scale(16.0f, 16.0f, 16.0f, MTXMODE_APPLY);
         GetItem_Draw(play, GID_BOMBCHU);
     } else {
+        // Ideally we would update spining flag and rotation in an Update func, but that is not convenient to do right
+        // now so opting to change here in the draw instead (upon toggle, the item may look incorrect for 1 frame).
+        CUSTOM_ITEM_FLAGS |= CustomItem::STOP_SPINNING;
+        actor->shape.rot.y = 0;
+
         POLY_OPA_DISP = Play_SetFog(play, POLY_OPA_DISP);
 
         POLY_OPA_DISP = Gfx_SetupDL66(POLY_OPA_DISP);
 
         Matrix_Scale(2.0f, 2.0f, 2.0f, MTXMODE_APPLY);
-        Matrix_ReplaceRotation(&play->billboardMtxF);
 
         gSPSegment(POLY_OPA_DISP++, 0x08, (uintptr_t)gDropBombchuTex);
 
@@ -37,6 +66,8 @@ static void ChuDrop_Draw(Actor* actor, PlayState* play) {
 
         gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gItemDropDL);
     }
+
+    FrameInterpolation_RecordCloseChild();
 
     CLOSE_DISPS(play->state.gfxCtx);
 }
@@ -46,9 +77,16 @@ void RegisterChuDrops() {
         if (actor->params == ITEM00_BOMBS_0 || actor->params == ITEM00_BOMBS_A || actor->params == ITEM00_BOMBS_B) {
             if (rand() % 100 < 50) {
                 *should = false;
-                CustomItem::Spawn(actor->world.pos.x, actor->world.pos.y, actor->world.pos.z, 0,
-                                  CustomItem::GIVE_OVERHEAD | CustomItem::TOSS_ON_SPAWN, GID_BOMBCHU, ChuDrop_Give,
-                                  ChuDrop_Draw);
+                EnItem00* newItem =
+                    CustomItem::Spawn(actor->world.pos.x, actor->world.pos.y, actor->world.pos.z, 0,
+                                      CustomItem::GIVE_OVERHEAD | CustomItem::TOSS_ON_SPAWN | CustomItem::STOP_BOBBING,
+                                      GID_BOMBCHU, ChuDrop_Give, ChuDrop_Draw);
+
+                // Set actor shadow and yOffset to match normal drops
+                ActorShape_Init(&newItem->actor.shape, 640.0f, ActorShadow_DrawCircle, 12.0f);
+                newItem->actor.shape.shadowAlpha = 180;
+                // Default gravity in CustomItem is too heavy, using a smaller value here to align with item drops
+                newItem->actor.gravity = -1.0f;
             }
         }
     });


### PR DESCRIPTION
This improves the display and behavior of Chu drops:

* 2D is now billboarded correctly
* Chu drops have stop bobbing on to match drops
* Adjusted CustomItem to clear gravity and speed on pickup, so that items marked as `TOSS` do not "sink" when picked up
* Made Chu drops render sparkles when falling with gravity (similar to normal item00 drops). I feel like this should belong within `CustomItem` directly, but there are a couple things I'd like to do to the `CustomItem` code in general, so I'll save that for a follow up PR.
* `STOP_BOBBING` no longer forces a yOffset of `1250.0f`. This aligns with normal item00 behavior and allows the chu drops to be placed lower to the ground by setting a yOffset during init.
* Added actor shadows to chu drops. Again this is probably a candidate for being moved to `CustomItem` in a follow up PR
* Adjusted chu drop gravity to be less heavy so its toss arch resembles more like normal item00 drops. Not sure why `CustomItem` toss defaults to such heavy gravity, probably could be changed later.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2415362783.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2415377114.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2415570873.zip)
<!--- section:artifacts:end -->