### PR TITLE
Do not play Song of Healing cutscene on moon crash

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnOsn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnOsn.cpp
@@ -19,4 +19,17 @@ void Rando::ActorBehavior::InitEnOsnBehavior() {
         RANDO_SAVE_CHECKS[RC_CLOCK_TOWER_INTERIOR_DEKU_MASK].eligible = true;
         RANDO_SAVE_CHECKS[RC_CLOCK_TOWER_INTERIOR_SONG_OF_HEALING].eligible = true;
     });
+
+    /*
+     * When the player enters the Clock Tower Interior entrance 3, the Happy Mask Salesman actor will play one of two
+     * cutscenes: learning the Song of Healing (csId 11), or the typical moon crash cycle reset (csId 13). In rando, the
+     * former is never expected. Moon crashes in rando can inadvertently trigger the Song of Healing scene, so we'll
+     * just quietly change to the intended cutscene.
+     */
+    COND_VB_SHOULD(VB_START_CUTSCENE, IS_RANDO, {
+        s16* csId = va_arg(args, s16*);
+        if (gPlayState->sceneId == SCENE_INSIDETOWER && *csId == 11) { // Song of Healing tutorial
+            *csId = 13;                                                // Moon crash new cycle scene
+        }
+    });
 }


### PR DESCRIPTION
Clock Tower Interior entrance 3 causes the Happy Mask Salesman actor to play one of two cutscenes immediately: either the Song of Healing tutorial, or the typical moon crash cycle reset cutscene. This is determined by the presence of the Ocarina of Time and Deku Mask in the player's inventory. Since it is possible to not have the Deku Mask upon moon crash in rando, the player can end up learning the Song of Healing instead. As this cutscene is never expected in rando, the simple fix is to just change the cutscene.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2416092490.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2416098815.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2416111476.zip)
<!--- section:artifacts:end -->