### PR TITLE
Deku Grotto + Ranch related corrections

### DIFF
--- a/mm/2s2h/Rando/Logic/Regions/South.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/South.cpp
@@ -258,7 +258,7 @@ static RegisterShipInitFunc initFunc([]() {
         },
         .events = {
             // TODO : Check what is effective against aliens.
-            EVENT_WEEKEVENTREG("Defended Cows from Aliens", WEEKEVENTREG_DEFENDED_AGAINST_THEM, CAN_BE_GORON && HAS_ITEM(POWDER_KEG) && (CAN_USE_HUMAN_SWORD || HAS_ITEM(ITEM_HOOKSHOT) || HAS_ITEM(ITEM_BOW))),
+            EVENT_WEEKEVENTREG("Defended Cows from Aliens", WEEKEVENTREG_DEFENDED_AGAINST_THEM, CAN_BE_GORON && HAS_ITEM(POWDER_KEG) && HAS_ITEM(ITEM_BOW)),
         },
     };
     Regions[RR_SOUTHERN_SWAMP_GROTTO] = RandoRegion{ .name = "Southern Swamp Grotto", .sceneId = SCENE_KAKUSIANA,

--- a/mm/2s2h/Rando/Logic/Regions/South.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/South.cpp
@@ -37,7 +37,7 @@ static RegisterShipInitFunc initFunc([]() {
     };
     Regions[RR_DEKU_PALACE_BEAN_SALESMAN_GROTTO] = RandoRegion{ .name = "Deku Palace Bean Salesman Grotto", .sceneId = SCENE_KAKUSIANA,
         .checks = {
-            CHECK(RC_DEKU_PALACE_GROTTO_CHEST, CAN_GROW_BEAN_PLANT),
+            CHECK(RC_DEKU_PALACE_GROTTO_CHEST, CAN_GROW_BEAN_PLANT || HAS_ITEM(ITEM_HOOKSHOT)),
             // TODO: Bean salesman check
         },
         .exits = { //     TO                                         FROM

--- a/mm/2s2h/Rando/Logic/Regions/South.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/South.cpp
@@ -158,6 +158,7 @@ static RegisterShipInitFunc initFunc([]() {
     };
     Regions[RR_GORMAN_TRACK] = RandoRegion{ .sceneId = SCENE_KOEPONARACE,
         .checks = {
+            // TODO : Also apparently can be obtained using a trick with Goron mask and Bombs. Add trick later here
             CHECK(RC_GORMAN_TRACK_LARGE_CRATE, CHECK_WEEKEVENTREG(WEEKEVENTREG_DEFENDED_AGAINST_THEM)), // Night 2 only, after defending cows from aliens.
             CHECK(RC_GORMAN_TRACK_GARO_MASK, CAN_PLAY_SONG(EPONA)),
         },
@@ -247,7 +248,7 @@ static RegisterShipInitFunc initFunc([]() {
             CHECK(RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_BACK, CAN_PLAY_SONG(EPONA) && CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG)),
             CHECK(RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_FRONT, CAN_PLAY_SONG(EPONA) && CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG)),
             CHECK(RC_ROMANI_RANCH_FIELD_LARGE_CRATE, true),
-            CHECK(RC_CREMIA_ESCORT, HAS_ITEM(ITEM_BOW) CHECK_WEEKEVENTREG(WEEKEVENTREG_DEFENDED_AGAINST_THEM)),
+            CHECK(RC_CREMIA_ESCORT, HAS_ITEM(ITEM_BOW) && CHECK_WEEKEVENTREG(WEEKEVENTREG_DEFENDED_AGAINST_THEM)),
         },
         .exits = { //     TO                                         FROM
             EXIT(ENTRANCE(MILK_ROAD, 1),                    ENTRANCE(ROMANI_RANCH, 0), true),
@@ -257,8 +258,7 @@ static RegisterShipInitFunc initFunc([]() {
             EXIT(ENTRANCE(DOGGY_RACETRACK, 0),              ENTRANCE(ROMANI_RANCH, 5), true),
         },
         .events = {
-            // TODO : Check what is effective against aliens.
-            EVENT_WEEKEVENTREG("Defended Cows from Aliens", WEEKEVENTREG_DEFENDED_AGAINST_THEM, CAN_BE_GORON && HAS_ITEM(POWDER_KEG) && HAS_ITEM(ITEM_BOW)),
+            EVENT_WEEKEVENTREG("Defended Cows from Aliens", WEEKEVENTREG_DEFENDED_AGAINST_THEM, CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG) && HAS_ITEM(ITEM_BOW)),
         },
     };
     Regions[RR_SOUTHERN_SWAMP_GROTTO] = RandoRegion{ .name = "Southern Swamp Grotto", .sceneId = SCENE_KAKUSIANA,

--- a/mm/2s2h/Rando/Logic/Regions/South.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/South.cpp
@@ -158,7 +158,7 @@ static RegisterShipInitFunc initFunc([]() {
     };
     Regions[RR_GORMAN_TRACK] = RandoRegion{ .sceneId = SCENE_KOEPONARACE,
         .checks = {
-            CHECK(RC_GORMAN_TRACK_LARGE_CRATE, CAN_PLAY_SONG(EPONA)),
+            CHECK(RC_GORMAN_TRACK_LARGE_CRATE, CHECK_WEEKEVENTREG(WEEKEVENTREG_DEFENDED_AGAINST_THEM)), // Night 2 only, after defending cows from aliens.
             CHECK(RC_GORMAN_TRACK_GARO_MASK, CAN_PLAY_SONG(EPONA)),
         },
         .exits = { //     TO                                         FROM
@@ -247,7 +247,7 @@ static RegisterShipInitFunc initFunc([]() {
             CHECK(RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_BACK, CAN_PLAY_SONG(EPONA) && CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG)),
             CHECK(RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_FRONT, CAN_PLAY_SONG(EPONA) && CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG)),
             CHECK(RC_ROMANI_RANCH_FIELD_LARGE_CRATE, true),
-            CHECK(RC_CREMIA_ESCORT, HAS_ITEM(ITEM_BOW) && CAN_BE_GORON && HAS_ITEM(ITEM_POWDER_KEG)),
+            CHECK(RC_CREMIA_ESCORT, HAS_ITEM(ITEM_BOW) CHECK_WEEKEVENTREG(WEEKEVENTREG_DEFENDED_AGAINST_THEM)),
         },
         .exits = { //     TO                                         FROM
             EXIT(ENTRANCE(MILK_ROAD, 1),                    ENTRANCE(ROMANI_RANCH, 0), true),
@@ -255,6 +255,10 @@ static RegisterShipInitFunc initFunc([]() {
             EXIT(ENTRANCE(RANCH_HOUSE, 1),                  ENTRANCE(ROMANI_RANCH, 3), true), // House
             EXIT(ENTRANCE(CUCCO_SHACK, 0),                  ENTRANCE(ROMANI_RANCH, 4), true),
             EXIT(ENTRANCE(DOGGY_RACETRACK, 0),              ENTRANCE(ROMANI_RANCH, 5), true),
+        },
+        .events = {
+            // TODO : Check what is effective against aliens.
+            EVENT_WEEKEVENTREG("Defended Cows from Aliens", WEEKEVENTREG_DEFENDED_AGAINST_THEM, CAN_BE_GORON && HAS_ITEM(POWDER_KEG) && (CAN_USE_HUMAN_SWORD || HAS_ITEM(ITEM_HOOKSHOT) || HAS_ITEM(ITEM_BOW))),
         },
     };
     Regions[RR_SOUTHERN_SWAMP_GROTTO] = RandoRegion{ .name = "Southern Swamp Grotto", .sceneId = SCENE_KAKUSIANA,


### PR DESCRIPTION
Added HAS_ITEM(ITEM_HOOKSHOT) to requirements for reaching the chest in the Deku Palace Bean Grotto.

Also added a event for killing aliens, added the event check as a requirement for the Cremia escort. And added proper logic for the crate in Gorman track that normally requires you to defend the cows from Aliens first and is only accessible during Night 2.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2419900166.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2419906384.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2419923187.zip)
<!--- section:artifacts:end -->