### PR TITLE
Add additional item tracker entries

### DIFF
--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.h
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.h
@@ -16,7 +16,10 @@ typedef enum class ItemTrackerDisplayType : int8_t {
 typedef enum {
     SECTION_INVENTORY,
     SECTION_MASKS,
+    SECTION_EQUIPMENT,
+    SECTION_MISC,
     SECTION_SONGS,
+    SECTION_STRAY_FAIRIES,
     SECTION_DUNGEON,
     SECTION_MAX,
 } ItemTrackerSection;
@@ -35,6 +38,12 @@ class ItemTrackerWindow : public Ship::GuiWindow {
         uint8_t maxCap;
     } AmmoInfo;
 
+    typedef struct CountInfo {
+        uint16_t cur;
+        uint16_t curCap;
+        uint16_t maxCap;
+    } CountInfo;
+
   public:
     using GuiWindow::GuiWindow;
     ~ItemTrackerWindow();
@@ -48,6 +57,7 @@ class ItemTrackerWindow : public Ship::GuiWindow {
     TrackerWindowType* GetWindowTypePtr();
     bool* GetIsDraggablePtr();
     bool* GetOnlyShowPausedPtr();
+    bool* GetIncludeMapsAndCompassesPtr();
     ItemTrackerDisplayType* GetDrawModePtr(ItemTrackerSection type);
     bool* GetCapacityModePtr(ItemTrackerCapacityMode mode);
     void LoadSettings();
@@ -62,9 +72,16 @@ class ItemTrackerWindow : public Ship::GuiWindow {
     void DrawItemsInRows(int columns = 6);
     int DrawItems(int columns, int startAt);
     int DrawMasks(int columns, int startAt);
+    int DrawEquipment(int columns, int startAt);
+    int DrawMisc(int columns, int startAt);
     int DrawSongs(int columns, int startAt);
+    int DrawStrayFairies(int columns, int startAt);
     void DrawNote(size_t songIndex, bool drawFaded);
+    void DrawOwlFace(bool drawFaded);
     int DrawDungeonItemsVert(int columns, int startAt);
+    void DrawItemCount(int itemId, const ImVec2& iconPos);
+    CountInfo GetItemCountInfo(int itemId);
+    bool HasItemCount(int itemId);
     void DrawAmmoCount(int itemId, const ImVec2& iconPos);
     bool HasAmmoCount(int itemId);
     AmmoInfo GetAmmoInfo(int itemId);
@@ -77,6 +94,7 @@ class ItemTrackerWindow : public Ship::GuiWindow {
     TrackerWindowType mWindowType = TrackerWindowType::Floating;
     bool mIsDraggable = false;
     bool mOnlyDrawPaused = false;
+    bool mIncludeMapsAndCompasses = false;
     std::array<bool, DrawCapacityMax> mCapacityModes;
     std::array<ItemTrackerDisplayType, SECTION_MAX> mItemDrawModes;
 };

--- a/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.cpp
@@ -58,8 +58,14 @@ void ItemTrackerSettingsWindow::DrawElement() {
 
     UIWidgets::Combobox("Inventory", mItemTrackerWindow->GetDrawModePtr(SECTION_INVENTORY), displayTypes);
     UIWidgets::Combobox("Masks", mItemTrackerWindow->GetDrawModePtr(SECTION_MASKS), displayTypes);
+    UIWidgets::Combobox("Equipment", mItemTrackerWindow->GetDrawModePtr(SECTION_EQUIPMENT), displayTypes);
+    UIWidgets::Combobox("Miscellaneous", mItemTrackerWindow->GetDrawModePtr(SECTION_MISC), displayTypes);
     UIWidgets::Combobox("Songs", mItemTrackerWindow->GetDrawModePtr(SECTION_SONGS), displayTypes);
+    UIWidgets::Combobox("Stray Fairies", mItemTrackerWindow->GetDrawModePtr(SECTION_STRAY_FAIRIES), displayTypes);
     UIWidgets::Combobox("Dungeon Items", mItemTrackerWindow->GetDrawModePtr(SECTION_DUNGEON), displayTypes);
+
+    UIWidgets::Checkbox("Include Maps and Compasses", mItemTrackerWindow->GetIncludeMapsAndCompassesPtr(),
+                        { .tooltip = "Includes Maps and Compasses with the Dungeon Items section" });
 
     UIWidgets::Checkbox("Draw Current Ammo",
                         mItemTrackerWindow->GetCapacityModePtr(ItemTrackerCapacityMode::DrawCurrent));

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
@@ -104,8 +104,8 @@ std::string totalChecksFound() {
 void DrawCheckTypeIcon(RandoCheckId randoCheckId) {
     RandoCheckType checkType = Rando::StaticData::Checks[randoCheckId].randoCheckType;
     ImGui::Image(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(checkTypeIconList[checkType]),
-                 checkType == RCTYPE_SONG  ? ImVec2(14.0f * trackerScale, 18.0f * trackerScale)
-                 : checkType == RCTYPE_OWL ? ImVec2(18.0f * trackerScale, 11.0f * trackerScale)
+                 checkType == RCTYPE_SONG  ? ImVec2(12.0f * trackerScale, 18.0f * trackerScale)
+                 : checkType == RCTYPE_OWL ? ImVec2(18.0f * trackerScale, 9.0f * trackerScale)
                                            : ImVec2(18.0f * trackerScale, 18.0f * trackerScale),
                  ImVec2(0, 0), ImVec2(1, 1),
                  checkType == RCTYPE_FREESTANDING ? ImVec4(0.78f, 1, 0.39f, 1) : ImVec4(1, 1, 1, 1));

--- a/mm/2s2h/ShipUtils.cpp
+++ b/mm/2s2h/ShipUtils.cpp
@@ -12,13 +12,13 @@
 #include "assets/interface/parameter_static/parameter_static.h"
 #include "assets/archives/icon_item_24_static/icon_item_24_static_yar.h"
 #include "assets/archives/schedule_dma_static/schedule_dma_static_yar.h"
+#include "assets/interface/icon_item_dungeon_static/icon_item_dungeon_static.h"
 #include "assets/interface/icon_item_field_static/icon_item_field_static.h"
 
 extern "C" {
 #include "z64.h"
 #include "functions.h"
 #include "macros.h"
-#include "z64.h"
 
 extern float OTRGetAspectRatio();
 
@@ -44,19 +44,23 @@ std::unordered_map<s16, const char*> sceneNames = {
 
 // These textures are not in existing lists that we iterate over.
 std::vector<const char*> miscellaneousTextures = {
-    gRupeeCounterIconTex,
-    gStrayFairyGreatBayIconTex,
-    gQuestIconGoldSkulltulaTex,
-    gWorldMapOwlFaceTex,
-    gChestTrackerIcon,
-    gPotTrackerIcon,
     gArcheryScoreIconTex,
     gBarrelTrackerIcon,
+    gChestTrackerIcon,
     gCrateTrackerIcon,
-    gTimerClockIconTex,
-    gStrayFairyStoneTowerIconTex,
+    gDungeonStrayFairyGreatBayIconTex,
+    gDungeonStrayFairySnowheadIconTex,
+    gDungeonStrayFairyStoneTowerIconTex,
+    gDungeonStrayFairyWoodfallIconTex,
+    gPotTrackerIcon,
+    gQuestIconGoldSkulltulaTex,
+    gRupeeCounterIconTex,
+    gStrayFairyGreatBayIconTex,
     gStrayFairySnowheadIconTex,
+    gStrayFairyStoneTowerIconTex,
     gStrayFairyWoodfallIconTex,
+    gTimerClockIconTex,
+    gWorldMapOwlFaceTex,
 };
 
 std::vector<const char*> digitList = { gCounterDigit0Tex, gCounterDigit1Tex, gCounterDigit2Tex, gCounterDigit3Tex,


### PR DESCRIPTION
Adds additional item tracker entires:

* Equipment: Sword & Shield 
* Miscellaneous: Notebook, Wallet, Magic, Owl activations
* Stray Fairies: Temples + Clock Town
* Dungeon Items now includes small keys
* Option to remove maps and compasses from Dungeon Items

Not super happy with the general item tracker flow, but this is enough to at least just "have things working"

Also makes it so the stray fairy icons used by the save editor now load properly 🙂 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2425345341.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2425364777.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2425399507.zip)
<!--- section:artifacts:end -->