### PR TITLE
Fix custom message formatting and gossip stone hint text

### DIFF
--- a/mm/2s2h/CustomMessage/CustomMessage.cpp
+++ b/mm/2s2h/CustomMessage/CustomMessage.cpp
@@ -51,8 +51,15 @@ void CustomMessage::AddLineBreaks(std::string* msg) {
     for (size_t i = 0; i < msg->size(); ++i) {
         char currentChar = (*msg)[i];
 
-        if (currentChar >= 0x20 && currentChar < 0x20 + sizeof(sNESFontWidths) / sizeof(sNESFontWidths[0])) {
+        if ((uint8_t)currentChar >= 0x20 && (uint8_t)currentChar < 0x20 + ARRAY_COUNTU(sNESFontWidths)) {
             currentLineWidth += sNESFontWidths[currentChar - 0x20];
+        }
+
+        // Increment for existing new liens
+        if (currentChar == 0x11) {
+            currentLineWidth = 0.0f;
+            lastSpaceIndex = std::string::npos;
+            ++currentLineCount;
         }
 
         if (currentChar == ' ') {
@@ -71,8 +78,8 @@ void CustomMessage::AddLineBreaks(std::string* msg) {
             ++currentLineCount;
 
             if (currentLineCount >= MAX_LINES_PER_PAGE) {
-                msg->insert(i + 1, 1, 0x10);
-                ++i;
+                // Replace the added new line for a box break instead
+                (*msg)[i] = 0x10;
                 currentLineCount = 0;
             }
         }
@@ -81,7 +88,7 @@ void CustomMessage::AddLineBreaks(std::string* msg) {
 
 // Ensure that the message ends with the message end character
 void CustomMessage::EnsureMessageEnd(std::string* msg) {
-    if (msg->back() != 0xBF) {
+    if ((unsigned char)msg->back() != 0xBF) {
         msg->push_back(0xBF);
     }
 }
@@ -129,10 +136,10 @@ void CustomMessage::LoadCustomMessageIntoFont(CustomMessage::Entry entry) {
     buff[10] = 0xFF;
 
     if (entry.autoFormat) {
-        CustomMessage::AddLineBreaks(&entry.msg);
         CustomMessage::ReplaceColorChars(&entry.msg);
-        CustomMessage::EnsureMessageEnd(&entry.msg);
         CustomMessage::Replace(&entry.msg, "\n", "\x11");
+        CustomMessage::AddLineBreaks(&entry.msg);
+        CustomMessage::EnsureMessageEnd(&entry.msg);
     }
 
     // If message is too long, truncate it and add the message end character

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -6,6 +6,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/BenGui/Notification.h"
 #include "2s2h/Rando/Spoiler/Spoiler.h"
+#include "2s2h/ShipUtils.h"
 
 #include "interface/icon_item_dungeon_static/icon_item_dungeon_static.h"
 #include "archives/icon_item_24_static/icon_item_24_static_yar.h"
@@ -892,7 +893,7 @@ void DrawItemsAndMasksTab() {
                         [](Actor* actor, PlayState* play) {
                             RandoItemId randoItemId = Rando::ConvertItem((RandoItemId)CUSTOM_ITEM_PARAM);
                             std::string msg = "You received";
-                            if (Rando::StaticData::Items[randoItemId].article != "") {
+                            if (!Ship_IsCStringEmpty(Rando::StaticData::Items[randoItemId].article)) {
                                 msg += " ";
                                 msg += Rando::StaticData::Items[randoItemId].article;
                             }

--- a/mm/2s2h/Rando/ActorBehavior/EnAkindonuts.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAkindonuts.cpp
@@ -1,5 +1,6 @@
 #include "ActorBehavior.h"
 #include <libultraship/libultraship.h>
+#include "2s2h/ShipUtils.h"
 
 extern "C" {
 #include "variables.h"
@@ -25,7 +26,7 @@ void EnAkindonuts_ReplacePurchaseMessage(RandoCheckId randoCheckId, RandoInf ran
     auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
     entry.msg = "I'll sell you {{article}}%g{{item}}%w for %r{{rupees}} Rupees%w!\xE0";
 
-    if (randoStaticItem.article != "") {
+    if (!Ship_IsCStringEmpty(randoStaticItem.article)) {
         CustomMessage::Replace(&entry.msg, "{{article}}", std::string(randoStaticItem.article) + " ");
     } else {
         CustomMessage::Replace(&entry.msg, "{{article}}", "");

--- a/mm/2s2h/Rando/ActorBehavior/EnGs.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGs.cpp
@@ -83,9 +83,9 @@ void Rando::ActorBehavior::InitEnGsBehavior() {
         entry.autoFormat = false;
         auto& saveCheck = RANDO_SAVE_CHECKS[randoCheckId];
 
-        entry.msg = "They say %g{{article}}{{item}}%w is hidden at %y{{location}}%w.\x11";
+        entry.msg = "They say %g{{article}}{{item}}%w is hidden at %y{{location}}%w.";
 
-        if (Rando::StaticData::Items[saveCheck.randoItemId].article != "") {
+        if (!Ship_IsCStringEmpty(Rando::StaticData::Items[saveCheck.randoItemId].article)) {
             CustomMessage::Replace(&entry.msg, "{{article}}",
                                    std::string(Rando::StaticData::Items[saveCheck.randoItemId].article) + " ");
         } else {
@@ -95,10 +95,13 @@ void Rando::ActorBehavior::InitEnGsBehavior() {
         CustomMessage::Replace(&entry.msg, "{{item}}", Rando::StaticData::Items[saveCheck.randoItemId].name);
         CustomMessage::Replace(&entry.msg, "{{location}}", readableCheckNamesForGs[randoCheckId]);
 
+        // Replace colors before line break calculation
+        CustomMessage::ReplaceColorChars(&entry.msg);
+
         CustomMessage::AddLineBreaks(&entry.msg);
 
         // Eventually this part should be opt-in, but for now it's always on
-        entry.msg += "\x13\x12...\x13\x12Trade %r{{rupees}} Rupees%w for another hint?\x11\xC2No\x11Yes";
+        entry.msg += "\x10...\x13\x12Trade %r{{rupees}} Rupees%w for another hint?\x11\xC2No\x11Yes";
         s32 cost = GetNormalizedCost();
         CustomMessage::Replace(&entry.msg, "{{rupees}}", std::to_string(cost));
 
@@ -127,7 +130,7 @@ void Rando::ActorBehavior::InitEnGsBehavior() {
 
                 entry.msg = "Wise choice... They say %g{{article}}{{item}}%w is hidden at %y{{location}}%w.";
 
-                if (Rando::StaticData::Items[saveCheck.randoItemId].article != "") {
+                if (!Ship_IsCStringEmpty(Rando::StaticData::Items[saveCheck.randoItemId].article)) {
                     CustomMessage::Replace(&entry.msg, "{{article}}",
                                            std::string(Rando::StaticData::Items[saveCheck.randoItemId].article) + " ");
                 } else {

--- a/mm/2s2h/Rando/ActorBehavior/EnKgy.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnKgy.cpp
@@ -1,5 +1,6 @@
 #include "ActorBehavior.h"
 #include <libultraship/libultraship.h>
+#include "2s2h/ShipUtils.h"
 
 extern "C" {
 #include "variables.h"
@@ -49,7 +50,7 @@ void Rando::ActorBehavior::InitEnKgyBehavior() {
         if (!randoRazorSwordSaveCheck.obtained) {
             entry.autoFormat = false;
             std::string itemName;
-            if (Rando::StaticData::Items[randoRazorSwordSaveCheck.randoItemId].article != "") {
+            if (!Ship_IsCStringEmpty(Rando::StaticData::Items[randoRazorSwordSaveCheck.randoItemId].article)) {
                 itemName += Rando::StaticData::Items[randoRazorSwordSaveCheck.randoItemId].article;
                 itemName += " ";
             }
@@ -79,7 +80,7 @@ void Rando::ActorBehavior::InitEnKgyBehavior() {
 
         if (!RANDO_SAVE_CHECKS[RC_MOUNTAIN_VILLAGE_SMITHY_GILDED_SWORD].eligible) {
             RandoSaveCheck& randoGildedSwordSaveCheck = RANDO_SAVE_CHECKS[RC_MOUNTAIN_VILLAGE_SMITHY_GILDED_SWORD];
-            if (Rando::StaticData::Items[randoGildedSwordSaveCheck.randoItemId].article != "") {
+            if (!Ship_IsCStringEmpty(Rando::StaticData::Items[randoGildedSwordSaveCheck.randoItemId].article)) {
                 itemName = Rando::StaticData::Items[randoGildedSwordSaveCheck.randoItemId].article;
                 itemName += " ";
             } else {

--- a/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -5,6 +5,7 @@
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/BenGui/Notification.h"
 #include "2s2h/Rando/StaticData/StaticData.h"
+#include "2s2h/ShipUtils.h"
 
 extern "C" {
 #include "variables.h"
@@ -44,7 +45,7 @@ void Rando::MiscBehavior::CheckQueue() {
                         RandoItemId randoItemId =
                             Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM);
                         std::string msg = "You received";
-                        if (Rando::StaticData::Items[randoItemId].article != "") {
+                        if (!Ship_IsCStringEmpty(Rando::StaticData::Items[randoItemId].article)) {
                             msg += " ";
                             msg += Rando::StaticData::Items[randoItemId].article;
                         }


### PR DESCRIPTION
Fixes a few things with custom message formatting and gossip stone hint text, as well as some UB cleanup:

* Line break calculation was not accounting for existing line breaks
* Rearranged auto format so that line break calculation happens after color code and new line char replacements
* Line break calculation when adding a box break now replaces the previously added newline. The newline was carrying over to the next message which we don't want.
* Various places where comparing the rando item `article` which is a cstring, against a string literal. This is not legal and is undefined behavior. Proper string comparison functions should be used instead. Updated to use our `Ship_IsCStringEmpty()`
* Various casting to fix incorrect signed comparison issues that weren't evaluating correctly
---
* The gossip stone text had an erroneous new line added at the end of the text which was tripping up the auto formatter. Removed as it seemed to serve no purpose.
* The gossip stone text was using a `CARRIAGE_RETURN BOX_BREAK2` instead of a `BOX_BREAK` between the first hint and the "... buy another hint" text. This causes the first hint to be pushed done more in rendering, leaving awkward space at the top of the message. Switched to `BOX_BREAK` instead.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2432899214.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2432909279.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2432938787.zip)
<!--- section:artifacts:end -->