### PR TITLE
TWEAK: Green control code for new hint validation

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnGs.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGs.cpp
@@ -101,7 +101,7 @@ void Rando::ActorBehavior::InitEnGsBehavior() {
         CustomMessage::AddLineBreaks(&entry.msg);
 
         // Eventually this part should be opt-in, but for now it's always on
-        entry.msg += "\x10...\x13\x12Trade %r{{rupees}} Rupees%w for another hint?\x11\xC2No\x11Yes";
+        entry.msg += "\x10...\x13\x12Trade %r{{rupees}} Rupees%w for another hint?\x02\x11\xC2No\x11Yes";
         s32 cost = GetNormalizedCost();
         CustomMessage::Replace(&entry.msg, "{{rupees}}", std::to_string(cost));
 


### PR DESCRIPTION
Simply add the classic green color for the validation choice
![image](https://github.com/user-attachments/assets/8c4961be-6b31-472b-9664-cbaab4b2c004)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2451393055.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2451395977.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2451430345.zip)
<!--- section:artifacts:end -->