### PR TITLE
Fix UB in CustomMessage.cpp

### DIFF
--- a/mm/2s2h/CustomMessage/CustomMessage.cpp
+++ b/mm/2s2h/CustomMessage/CustomMessage.cpp
@@ -52,7 +52,7 @@ void CustomMessage::AddLineBreaks(std::string* msg) {
         char currentChar = (*msg)[i];
 
         if ((uint8_t)currentChar >= 0x20 && (uint8_t)currentChar < 0x20 + ARRAY_COUNTU(sNESFontWidths)) {
-            currentLineWidth += sNESFontWidths[currentChar - 0x20];
+            currentLineWidth += sNESFontWidths[(uint8_t)currentChar - 0x20];
         }
 
         // Increment for existing new liens


### PR DESCRIPTION
Credit to @Archez for suggesting the fix. The short version is that directly using `sNESFontWidths[currentChar - 0x20]` could result in out of bounds reads. This manifested in certain Windows builds when talking to the Curiosity Shop and Bomb Shop owners, where the game would freeze and seemingly have a memory leak.

Because this is UB, there was much trouble in reproducing this locally, but I could get it with GitHub Actions builds. The `uint8_t` cast seems to fix this.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2449393574.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2449399990.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2449456664.zip)
<!--- section:artifacts:end -->