### PR TITLE
Ensure scripted actors' skipCmds vectors clear on init

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnAl.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAl.cpp
@@ -9,14 +9,18 @@ void func_80848250(PlayState* play, Player* player);
 void Player_TalkWithPlayer(PlayState* play, Actor* actor);
 }
 
+static std::vector<u8> skipCmds = {};
+
 void Rando::ActorBehavior::InitEnAlBehavior() {
+
+    COND_ID_HOOK(OnActorInit, ACTOR_EN_AL, IS_RANDO, [](Actor* actor) { skipCmds.clear(); });
+
     COND_VB_SHOULD(VB_EXEC_MSG_EVENT, IS_RANDO, {
         u32 cmdId = va_arg(args, u32);
         Actor* actor = va_arg(args, Actor*);
 
         if (actor->id == ACTOR_EN_AL) { // Madame Aroma
             Player* player = GET_PLAYER(gPlayState);
-            static std::vector<u8> skipCmds = {};
 
             if (cmdId == MSCRIPT_CMD_06) { // MSCRIPT_OFFER_ITEM
                 *should = false;

--- a/mm/2s2h/Rando/ActorBehavior/EnAn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAn.cpp
@@ -7,14 +7,18 @@ void func_80837B60(PlayState* play, Player* player);
 s32 func_80832558(PlayState* play, Player* player, PlayerFuncD58 arg2);
 }
 
+static std::vector<u8> skipCmds = {};
+
 void Rando::ActorBehavior::InitEnAnBehavior() {
+
+    COND_ID_HOOK(OnActorInit, ACTOR_EN_AN, IS_RANDO, [](Actor* actor) { skipCmds.clear(); });
+
     COND_VB_SHOULD(VB_EXEC_MSG_EVENT, IS_RANDO, {
         u32 cmdId = va_arg(args, u32);
         Actor* actor = va_arg(args, Actor*);
         if (actor->id == ACTOR_EN_AN) { // Anju
             MsgScript* script = va_arg(args, MsgScript*);
             Player* player = GET_PLAYER(gPlayState);
-            static std::vector<u8> skipCmds = {};
 
             if (cmdId == MSCRIPT_CMD_06) { // MSCRIPT_OFFER_ITEM
                 func_80832558(gPlayState, player, func_80837B60);

--- a/mm/2s2h/Rando/ActorBehavior/EnGo.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGo.cpp
@@ -10,14 +10,18 @@ void func_80837B60(PlayState* play, Player* player);
 s32 func_80832558(PlayState* play, Player* player, PlayerFuncD58 arg2);
 }
 
+static std::vector<u8> skipCmds = {};
+
 void Rando::ActorBehavior::InitEnGoBehavior() {
+
+    COND_ID_HOOK(OnActorInit, ACTOR_EN_GO, IS_RANDO, [](Actor* actor) { skipCmds.clear(); });
+
     // Scripted Actors
     COND_VB_SHOULD(VB_EXEC_MSG_EVENT, IS_RANDO, {
         u32 cmdId = va_arg(args, u32);
         Actor* actor = va_arg(args, Actor*);
         MsgScript* script = va_arg(args, MsgScript*);
         Player* player = GET_PLAYER(gPlayState);
-        static std::vector<u8> skipCmds = {};
 
         if (actor->id != ACTOR_EN_GO || ENGO_GET_TYPE(actor) != ENGO_MEDIGORON) {
             return;


### PR DESCRIPTION
Just some static variable cleanup. Theoretically, if a player were to reset during a scripted actor sequence when `skipCmds` is not empty, then that would result that scripted sequence being in an invalid state if the player were to engage with it again. This change clears the `skipCmds` vectors in the associated actor's OnInit hook, ensuring that the command skip state is clean prior to interaction.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2450065423.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2450070481.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2450071575.zip)
<!--- section:artifacts:end -->