### PR TITLE
fix show current scene option

### DIFF
--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
@@ -352,7 +352,7 @@ void CheckTrackerDrawNonLogicalList() {
                 continue;
             }
 
-            if (CVAR_SHOW_CURRENT_SCENE && Rando::StaticData::Checks[checkId].sceneId != gPlayState->sceneId) {
+            if (CVAR_SHOW_CURRENT_SCENE && Play_GetOriginalSceneId(Rando::StaticData::Checks[checkId].sceneId) != Play_GetOriginalSceneId(gPlayState->sceneId)) {
                 continue;
             }
 

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
@@ -352,7 +352,8 @@ void CheckTrackerDrawNonLogicalList() {
                 continue;
             }
 
-            if (CVAR_SHOW_CURRENT_SCENE && Play_GetOriginalSceneId(Rando::StaticData::Checks[checkId].sceneId) != Play_GetOriginalSceneId(gPlayState->sceneId)) {
+            if (CVAR_SHOW_CURRENT_SCENE && Play_GetOriginalSceneId(Rando::StaticData::Checks[checkId].sceneId) !=
+                                               Play_GetOriginalSceneId(gPlayState->sceneId)) {
                 continue;
             }
 


### PR DESCRIPTION
This lets "only show current scene" play nice with winter/spring & posioned/clear. With the setting, the tracker will now only show the "original" version of a scene no matter which version the player is currently in. 

Currently, all checks across two-set scenes are listed under the "original" version in the tracker. I can understand if this isn't ultimately desirable, but I prefer it this way, and I wouldn't be sure how to go about cleanly separating the checks in these kind of scenes anyway. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2451583478.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2451587876.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2451618007.zip)
<!--- section:artifacts:end -->