### PR TITLE
Fix Zora Hall bomb softlock in rando

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnZot.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnZot.cpp
@@ -12,7 +12,7 @@ void Rando::ActorBehavior::InitEnZotBehavior() {
         Actor* refActor = va_arg(args, Actor*);
         Player* player = GET_PLAYER(gPlayState);
 
-        if (refActor->id != ACTOR_EN_ZOT && gPlayState->sceneId != SCENE_33ZORACITY) {
+        if (refActor->id != ACTOR_EN_ZOT || gPlayState->sceneId != SCENE_33ZORACITY) {
             return;
         }
 
@@ -20,13 +20,12 @@ void Rando::ActorBehavior::InitEnZotBehavior() {
         // have any I am specifying the Params for the Zora Hall Scene Lights.
         if (refActor->params == -1015) {
             RANDO_SAVE_CHECKS[RC_ZORA_HALL_SCENE_LIGHTS].eligible = true;
+            *should = false;
+            refActor->parent = &player->actor;
+            player->talkActor = refActor;
+            player->talkActorDistance = refActor->xzDistToPlayer;
+            player->exchangeItemAction = PLAYER_IA_MINUS1;
+            Player_TalkWithPlayer(gPlayState, refActor);
         }
-
-        *should = false;
-        refActor->parent = &player->actor;
-        player->talkActor = refActor;
-        player->talkActorDistance = refActor->xzDistToPlayer;
-        player->exchangeItemAction = PLAYER_IA_MINUS1;
-        Player_TalkWithPlayer(gPlayState, refActor);
     });
 }


### PR DESCRIPTION
A Zora Hall lights check condition used `&&` where it should have been an `||`. For added safety, I moved the whole check processing within the condition that pertains to this particular Zora.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2463888501.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2463896775.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2463971687.zip)
<!--- section:artifacts:end -->