### PR TITLE
Fix: Add CAN_AFFORD logic to Goron Shop item checks

### DIFF
--- a/mm/2s2h/Rando/Logic/Regions/North.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/North.cpp
@@ -87,9 +87,9 @@ static RegisterShipInitFunc initFunc([]() {
     };
     Regions[RR_GORON_SHOP] = RandoRegion{ .sceneId = SCENE_GORONSHOP,
         .checks = {
-            CHECK(RC_GORON_SHOP_ITEM_01, true),
-            CHECK(RC_GORON_SHOP_ITEM_02, true),
-            CHECK(RC_GORON_SHOP_ITEM_03, true),
+            CHECK(RC_GORON_SHOP_ITEM_01, CAN_AFFORD(RC_GORON_SHOP_ITEM_01)),
+            CHECK(RC_GORON_SHOP_ITEM_02, CAN_AFFORD(RC_GORON_SHOP_ITEM_02)),
+            CHECK(RC_GORON_SHOP_ITEM_03, CAN_AFFORD(RC_GORON_SHOP_ITEM_03)),
         },
         .exits = { //     TO                                         FROM
             EXIT(ENTRANCE(GORON_SHRINE, 1),              ENTRANCE(GORON_SHOP, 0), true)


### PR DESCRIPTION
Ran into this issue while playing through the alpha - saw that the check tracker said I could pick up the Goron Shop items but the prices were too high for the starting wallet size to afford.

Relevant info for reference from spoiler file:
```
    "commitHash": "677a2fe",
    "finalSeed": 3606873388,
    "inputSeed": "1889637754",
    "options": {
        "RO_LOGIC": 0,
        "RO_SHUFFLE_BOSS_REMAINS": 0,
        "RO_SHUFFLE_GOLD_SKULLTULAS": 0,
        "RO_SHUFFLE_MUNDANE": 1,
        "RO_SHUFFLE_OWL_STATUES": 0,
        "RO_SHUFFLE_SHOPS": 1
    },
```