### PR TITLE
fix red potion bottle

### DIFF
--- a/mm/2s2h/Rando/ConvertItem.cpp
+++ b/mm/2s2h/Rando/ConvertItem.cpp
@@ -285,6 +285,7 @@ bool Rando::IsItemObtainable(RandoItemId randoItemId, RandoCheckId randoCheckId)
         case RI_BOTTLE_CHATEAU_ROMANI:
         case RI_BOTTLE_MILK:
         case RI_BOTTLE_GOLD_DUST:
+        case RI_BOTTLE_RED_POTION:
             if (hasObtainedCheck) {
                 return false;
             }
@@ -541,6 +542,10 @@ RandoItemId Rando::ConvertItem(RandoItemId randoItemId, RandoCheckId randoCheckI
                     return RI_MILK_REFILL;
                 }
                 break;
+            case RI_BOTTLE_RED_POTION:
+                if (Inventory_HasEmptyBottle()) {
+                    return RI_RED_POTION_REFILL;
+                }
             default:
                 break;
         }

--- a/mm/2s2h/Rando/GiveItem.cpp
+++ b/mm/2s2h/Rando/GiveItem.cpp
@@ -233,6 +233,11 @@ void Rando::GiveItem(RandoItemId randoItemId) {
             gSaveContext.healthAccumulator = gSaveContext.save.saveInfo.playerData.healthCapacity + 0x10;
             Item_Give(gPlayState, Rando::StaticData::Items[randoItemId].itemId);
             break;
+        case RI_BOTTLE_RED_POTION:
+            // ITEM_LONGSHOT will give a Red Potion bottle on the first available bottle slot
+            // ITEM_POTION_RED will put a Red Potion bottle on the first bottle slot
+            Item_Give(gPlayState, ITEM_LONGSHOT);
+            break;
         case RI_JUNK:
         case RI_NONE:
             break;


### PR DESCRIPTION
Red Potion bottle was always going on the first bottle slot. This corrects it to go on the first open bottle slot.

Also adds the convert stuff for the Red Potion Bottle. 

I tried changing the itemId for RI_BOTTLE_RED_POTION to ITEM_LONGSHOT instead, but that made the notification icon a Longshot. So I opted for the entry in `GiveItem.cpp`

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2486394277.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2486402253.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2486402855.zip)
<!--- section:artifacts:end -->