### PR TITLE
Feat: Add Moon Crash Cutscene Skip to Misc Interactions time savers

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMoonCrash.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMoonCrash.cpp
@@ -1,0 +1,42 @@
+#include <libultraship/bridge.h>
+#include <libultraship/luslog.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+}
+
+#define CVAR_NAME "gEnhancements.Cutscenes.SkipMiscInteractions"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+// Didn't end up using these few cutscene values, but they are captured here as documentation in case they
+// are relevant in the future
+#define TERMINA_FIELD_MOON_CRASH_CS_ENTRANCE 0x54C0
+#define VOID_FIRE_WALL_CS_ENTRANCE 0x1C00
+#define VOID_FIRE_WALL_CS_INDEX 0xFFF8
+
+#define MOON_CRASH_NEW_CYCLE_CS_ID 13
+#define MOON_CRASH_NEW_CYCLE_ENTRANCE_ID 0xC030
+
+/** 
+ *  Skips only the visible cutscenes (Clock Tower destruction and Link's terrible fate with the Fire Wall).
+ *  Note: There is a cutscene command SPECIFICALLY for resetting game state related to the moon crash,
+ *        CS_MISC_RESET_SAVE_FROM_MOON_CRASH, that MUST NOT be skipped, or else 
+ *        it would break the vanilla functionality of a Moon Crash reset.
+ */
+void RegisterSkipMoonCrash() {
+    // Skips initial cutscene in Termina Field where the moon falls, goes straight to clock tower cutscene
+    COND_VB_SHOULD(VB_PLAY_TRANSITION_CS, CVAR, {
+        if (gSaveContext.save.cutsceneIndex == 0x0 && gSaveContext.save.entrance == TERMINA_FIELD_MOON_CRASH_CS_ENTRANCE) {
+            // This cutscene command would otherwise be run as part of the Fire Wall cutscene that gets skipped.
+            // IT MUST BE CALLED HERE IF THAT CUTSCENE IS SKIPPED OR ELSE THE GAME STATE WILL NOT RESET CORRECTLY!
+            Sram_ResetSaveFromMoonCrash(&gPlayState->sramCtx);
+
+            gSaveContext.save.cutsceneIndex = MOON_CRASH_NEW_CYCLE_CS_ID;
+            gSaveContext.save.entrance = MOON_CRASH_NEW_CYCLE_ENTRANCE_ID;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSkipMoonCrash, { CVAR_NAME });


### PR DESCRIPTION
Getting a game over on the first cycle without saving after using Skip Intro Sequence creates a weird behavior that makes this cutscene skip seem strange - but it also occurs when the cutscene skip is not used. Seems to be an issue with the Skip Intro Sequence which is in use in all video examples here - I have added links here to view the behaviors for reference.

Link to view implementation behavior: https://www.youtube.com/watch?v=37N_wjt-yB4

Links to view quirky behavior when Moon Crash occurs on the first cycle without saving (Skip Misc Interactions enabled/disabled):
https://youtu.be/kvy4NSR1s9w (Moon Crash CS Enabled)
https://youtu.be/nB7_fK1Rmrc (Moon Crash CS Disabled)