### PR TITLE
Fix Captain Defeat CS crash

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipDefeatCaptainSequence.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipDefeatCaptainSequence.cpp
@@ -10,14 +10,13 @@ extern "C" {
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
-void SkipDefeatCaptainTextbox(EnBsb* captain) {
+void SkipDefeatCaptainTextbox() {
     // from func_80C0D9B4
     gPlayState->nextEntrance = Entrance_CreateFromSpawn(5);
     gSaveContext.nextCutsceneIndex = 0;
     gPlayState->transitionTrigger = 0x14;
     gPlayState->transitionType = 2;
     gSaveContext.nextTransitionType = 3;
-    captain->unk_111A = 0;
 }
 
 void SkipDefeatCaptainCutscene() {
@@ -41,8 +40,7 @@ void SkipDefeatCaptainCutscene() {
 void RegisterSkipDefeatCaptainSequence() {
     COND_VB_SHOULD(VB_PLAY_DEFEAT_CAPTAIN_SEQUENCE, CVAR, {
         *should = false;
-        EnBsb* captain = (EnBsb*)va_arg(args, EnBsb*);
-        SkipDefeatCaptainTextbox(captain);
+        SkipDefeatCaptainTextbox();
     });
 
     COND_VB_SHOULD(VB_START_CUTSCENE, CVAR, {

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipDefeatCaptainSequence.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipDefeatCaptainSequence.cpp
@@ -4,7 +4,7 @@
 
 extern "C" {
 #include "variables.h"
-#include "overlays/actors/ovl_En_Bsb/z_en_bsb.h"
+#include "functions.h"
 }
 
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"


### PR DESCRIPTION
#201 added a hook that expects the Keeta actor to be passed in, but it actually isn't, leading to either crashes or other undefined behavior. Since the `unk_111A` assignment isn't actually needed with the cutscene skipped, this PR simply removes the unneeded `EnBsb*`.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2501545691.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2501558047.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2501604180.zip)
<!--- section:artifacts:end -->