### PR TITLE
Corrected logic issue where Deku bubble can trigger the hive cutscene

### DIFF
--- a/mm/2s2h/Rando/Logic/Regions/PiratesFortress.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/PiratesFortress.cpp
@@ -18,7 +18,7 @@ static RegisterShipInitFunc initFunc([]() {
             EXIT(ENTRANCE(PIRATES_FORTRESS, 2),             ENTRANCE(PIRATES_FORTRESS_INTERIOR, 1), true),
         },
         .events = {
-            EVENT_WEEKEVENTREG("Hit Beehive", WEEKEVENTREG_83_02, HAS_ITEM(ITEM_BOW)),
+            EVENT_WEEKEVENTREG("Hit Beehive", WEEKEVENTREG_83_02, (HAS_ITEM(ITEM_BOW) || (CAN_BE_DEKU && HAS_MAGIC))),
         },
     };
     Regions[RR_PIRATES_FORTRESS_CAPTAIN_ROOM] = RandoRegion{ .name = "Captain Room", .sceneId = SCENE_PIRATE,


### PR DESCRIPTION
Noticed this on the TODO and verified it.

Also tried to use other means that have not been accounted for(Hookshot and Zora Fins) but Hookshot cannot get past the bars, and while I can clip the Zora fins in with careful positioning, lining the shot right is difficult, and even if it does hit it seems to just destroy the hive instead of dropping it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2520965934.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2520977500.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2520981420.zip)
<!--- section:artifacts:end -->