### PR TITLE
Enhancement to stop Oceanside Spider House squatter from moving in early

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -922,6 +922,11 @@ void BenMenu::AddEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "Allows the player to keep the Express Mail in their inventory after delivering it "
             "the first time, so that both deliveries can be done within one cycle"));
+    AddWidget(path, "Stop Oceanside Spider House squatter", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Cycle.StopOceansideSpiderHouseSquatter")
+        .Options(
+            CheckboxOptions().Tooltip("The Oceanside Spider House squatter will not move in until the player interacts "
+                                      "with him. Forced on for randomizers."));
     AddWidget(path, "Unstable", WIDGET_SEPARATOR_TEXT).Options(WidgetOptions().Color(Colors::Orange));
     AddWidget(path, "Disable Save Delay", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Saving.DisableSaveDelay")

--- a/mm/2s2h/Enhancements/Cycle/OceansideSpiderHouseSquatter.cpp
+++ b/mm/2s2h/Enhancements/Cycle/OceansideSpiderHouseSquatter.cpp
@@ -1,0 +1,38 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+#include "2s2h/Rando/Rando.h"
+
+extern "C" {
+#include "functions.h"
+}
+
+#define CVAR_NAME "gEnhancements.Cycle.StopOceansideSpiderHouseSquatter"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterOceansideSpiderHouseSquatter() {
+    /*
+     * Normally, the Oceanside Spider House squatter appears at the entrance once the player has acquired the 30
+     * Skulltula tokens. Mikau's grave on Great Bay Coast, for some reason, sets the flag for the squatter to move in
+     * and sit in the inner area. If Link has not spoken to him before this point, his reward will be unavailable for
+     * the remainder of the cycle. This fix changes it so that this will not happen until the player speaks to the
+     * squatter. This is forced on for rando, as there is a good chance the player will find the 30th token outside of
+     * the Oceanside Spider House, meaning the player would have to cross Great Bay Coast to find the man, which would
+     * render the check unobtainable.
+     */
+    COND_HOOK(OnFlagSet, CVAR || IS_RANDO, [](FlagType flagType, u32 flag) {
+        if (flagType == FLAG_WEEK_EVENT_REG) {
+            if (flag == WEEKEVENTREG_OCEANSIDE_SPIDER_HOUSE_BUYER_MOVED_IN) {
+                // Quietly unset it, unless we received the reward
+                if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_OCEANSIDE_SPIDER_HOUSE_COLLECTED_REWARD)) {
+                    CLEAR_WEEKEVENTREG(WEEKEVENTREG_OCEANSIDE_SPIDER_HOUSE_BUYER_MOVED_IN);
+                }
+            } else if (flag == WEEKEVENTREG_OCEANSIDE_SPIDER_HOUSE_COLLECTED_REWARD) {
+                // Collected the reward, so go ahead and set the other flag
+                SET_WEEKEVENTREG(WEEKEVENTREG_OCEANSIDE_SPIDER_HOUSE_BUYER_MOVED_IN);
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterOceansideSpiderHouseSquatter, { CVAR_NAME, "IS_RANDO" });


### PR DESCRIPTION
The Oceanside Spider House squatter moves before the player talks to him. The weirdness is documented in more detail in the enhancement file, but in short he moves in whenever the player enters Great Bay Coast with the 30 tokens, NOT when the player talks to him. This enhancement changes it so that the player must talk to him before he moves in. This is optional for non-rando but forced on for rando because the vanilla behavior could render the check unobtainable.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2521437558.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2521443285.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2521452541.zip)
<!--- section:artifacts:end -->