### PR TITLE
Fix issues with opening save

### DIFF
--- a/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
@@ -42,10 +42,4 @@ void Rando::MiscBehavior::OnFileLoad() {
         *should = false;
         BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_B) = *item;
     });
-
-    // In Sram_OpenSave (right before this code runs) for non-owl saves, it overwrites the entrance to
-    // ENTRANCE(CUTSCENE, 0), we need to override that with our starting location (Harcoded to South Clock Town)
-    if (!gSaveContext.save.isOwlSave && IS_RANDO) {
-        gSaveContext.save.entrance = ENTRANCE(SOUTH_CLOCK_TOWN, 0);
-    }
 }

--- a/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -28,7 +28,7 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
         gSaveContext.save.hasTatl = true;
         gSaveContext.save.playerForm = PLAYER_FORM_HUMAN;
         gSaveContext.save.saveInfo.playerData.threeDayResetCount = 1;
-        gSaveContext.save.isFirstCycle = false;
+        gSaveContext.save.isFirstCycle = true;
         SET_WEEKEVENTREG(WEEKEVENTREG_59_04);                                                  // Tatl
         SET_WEEKEVENTREG(WEEKEVENTREG_31_04);                                                  // Tatl
         gSaveContext.save.saveInfo.permanentSceneFlags[SCENE_INSIDETOWER].switch0 |= (1 << 0); // Happy Mask Salesman


### PR DESCRIPTION
OnFileCreate.cpp was setting `isFirstCycle` to false, which was causing the came to always set your form to Human and attempting to start at `ENTRANCE(CUTSCENE, 0)` when opening the save. When Archez fixed the non-rando skip-first-cycle enhancement, he explained that `isFirstCycle` should always be true once the player has reached Clocktown. 

This PR sets `isFirstCycle` to true on file creation, and removes the hardcoded location overwrite to South Clock Town which is not needed when `isFirstCycle` is true. 

I think this will resolve the issues reported by people opening a save with Human Link wearing a transformation mask. I wasn't able to replicate the issue, but I assume it's some kind of mismatch between `save.equippedMask` and `save.playerForm`

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2521889050.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2521895732.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2521920408.zip)
<!--- section:artifacts:end -->