### PR TITLE
Prevent getting free sword on cycle resets

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnKgy.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnKgy.cpp
@@ -15,6 +15,10 @@ void Rando::ActorBehavior::InitEnKgyBehavior() {
 
         if (randoRazorSwordSaveCheck.obtained) {
             randoGildedSwordSaveCheck.eligible = true;
+
+            // Normally this bit is set to zero when you get your sword back. The DoNotResetRazorSword enhancement uses
+            // this bit, so we need to clear it
+            gSaveContext.save.saveInfo.permanentSceneFlags[SCENE_KAJIYA].unk_14 &= ~4;
         } else {
             randoRazorSwordSaveCheck.eligible = true;
             // Skip ahead to the textbox that normally plays after receiving the sword

--- a/mm/2s2h/Rando/MiscBehavior/OnCycleSave.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnCycleSave.cpp
@@ -82,4 +82,17 @@ void Rando::MiscBehavior::AfterEndOfCycleSave() {
     if (IsRenewable(RANDO_SAVE_CHECKS[RC_STARTING_ITEM_SONG_OF_HEALING].randoItemId)) {
         RANDO_SAVE_CHECKS[RC_STARTING_ITEM_SONG_OF_HEALING].eligible = true;
     }
+
+    // Override a cycle reset from trying to restore your sword if you don't have one
+    u8 curSword = (saveContextCopy.save.saveInfo.equips.equipment & gEquipMasks[EQUIP_TYPE_SWORD]) >>
+                  gEquipShifts[EQUIP_TYPE_SWORD];
+    u8 stolen1 = ((saveContextCopy.save.saveInfo.stolenItems & 0xFF000000) >> 0x18);
+    u8 stolen2 = ((saveContextCopy.save.saveInfo.stolenItems & 0x00FF0000) >> 0x10);
+
+    // Check for sword not being stolen. Rando doesn't turn sword in to the smithy, so don't need to check that
+    if (curSword == EQUIP_VALUE_SWORD_NONE && !((stolen1 >= ITEM_SWORD_KOKIRI && stolen1 <= ITEM_SWORD_GILDED) ||
+                                                (stolen2 >= ITEM_SWORD_KOKIRI && stolen2 <= ITEM_SWORD_GILDED))) {
+        SET_EQUIP_VALUE(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_NONE);
+        BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_B) = ITEM_NONE;
+    }
 }


### PR DESCRIPTION
`Sram_SaveEndOfCycle()` will give you a sword, whether that's a stolen gilded sword or just default you to a Kokiri sword. This will override that behavior, so if you haven't obtained a sword yet, you will continue to not have a sword on cycle resets. 

Additionally, this fixes an edge case that could occur between the 2nd Smithy check and the DoNotResetRazorSword enhancement that is forced on for rando, which would cause you to get a Razor Sword upon a cycle reset if 1) you got the 2nd smithy check, 2) your sword was stolen, and 3) you played SoT. 


Edit: I also considered how Epona stealing your sword would interact with this. Since Epona only removes it from B, not your equipment, this does not affect getting your sword back via SoT in this circumstance 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2552213354.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2552221734.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2552283964.zip)
<!--- section:artifacts:end -->