### PR TITLE
Ensure Goron Elder check available when calming baby Goron

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
@@ -30,6 +30,7 @@ void Rando::ActorBehavior::InitEnGKBehavior() {
         }
     });
 
+    // Played Lullaby Intro for Baby Goron
     COND_VB_SHOULD(VB_START_CUTSCENE, IS_RANDO, {
         s16* csId = va_arg(args, s16*);
         Actor* actor = va_arg(args, Actor*);
@@ -42,6 +43,14 @@ void Rando::ActorBehavior::InitEnGKBehavior() {
 
         enGk->unk_1E4 &= ~0x20;
         *should = false;
+        SET_WEEKEVENTREG(WEEKEVENTREG_24_80); // Ensure Goron Elder check is available
         RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].eligible = true;
+    });
+
+    // Played Full Lullaby for Baby Goron
+    COND_HOOK(OnSceneFlagSet, IS_RANDO, [](s16 sceneId, FlagType flagType, u32 flag) {
+        if (sceneId == SCENE_16GORON_HOUSE && flagType == FLAG_CYCL_SCENE_SWITCH && flag == 20) {
+            SET_WEEKEVENTREG(WEEKEVENTREG_24_80); // Ensure Goron Elder check is available
+        }
     });
 }


### PR DESCRIPTION
If the player plays the Lullaby to the baby Goron before talking to him, there would be no way to set the flag that the Goron Elder responds to for the check. This PR fixes that by seeing the flag in both the Lullaby Intro CS and in the flag set by playing the full Lullaby.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2559305600.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2559310437.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2559318397.zip)
<!--- section:artifacts:end -->