### PR TITLE
Fix unshuffled Boss Remains for No Logic and Nearly No Logic

### DIFF
--- a/mm/2s2h/Rando/Logic/NearlyNoLogic.cpp
+++ b/mm/2s2h/Rando/Logic/NearlyNoLogic.cpp
@@ -88,6 +88,13 @@ void ApplyNearlyNoLogicToSaveContext(std::unordered_map<RandoCheckId, bool>& che
             }
         }
     }
+
+    // Set unshuffled locations with their vanilla item
+    for (auto& [_, randoStaticCheck] : Rando::StaticData::Checks) {
+        if (!RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId].shuffled) {
+            RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId].randoItemId = randoStaticCheck.randoItemId;
+        }
+    }
 }
 
 } // namespace Logic

--- a/mm/2s2h/Rando/Logic/NoLogic.cpp
+++ b/mm/2s2h/Rando/Logic/NoLogic.cpp
@@ -24,6 +24,13 @@ void ApplyNoLogicToSaveContext(std::unordered_map<RandoCheckId, bool>& checkPool
         RANDO_SAVE_CHECKS[randoCheckId].randoItemId = itemPool.back();
         itemPool.pop_back();
     }
+
+    // Set unshuffled locations with their vanilla item
+    for (auto& [_, randoStaticCheck] : Rando::StaticData::Checks) {
+        if (!RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId].shuffled) {
+            RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId].randoItemId = randoStaticCheck.randoItemId;
+        }
+    }
 }
 
 } // namespace Logic


### PR DESCRIPTION
Unshuffled checks were getting set to RI_UNKNOWN with No Logic and Nearly No Logic, causing some unshuffled checks to give junk. This was particularly problematic on the Boss Warp checks when remains weren't shuffled, preventing you from getting the remains as they would be junk. 

I didn't see exactly where it's happening, but for Glitchless Logic, the unshuffled checks had their vanilla RIs instead of RI_UNKNOWN (ie  `RC_WOODFALL_TEMPLE_BOSS_WARP` was listed as unshuffled and `RI_REMAINS_ODOLWA`). To achieve this for No Logic and Nearly No Logic, at the end of the Applying Logic functions, I loop through all checks and set every unshuffled check to its vanilla RI.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2562531287.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2562549212.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2562595409.zip)
<!--- section:artifacts:end -->