### PR TITLE
Zora Cape .oneWayEntrances adjustments

### DIFF
--- a/mm/2s2h/Rando/Logic/Regions/West.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/West.cpp
@@ -150,6 +150,10 @@ static RegisterShipInitFunc initFunc([]() {
         .connections = {
             CONNECTION(RR_ZORA_CAPE, CAN_BE_ZORA),
         },
+        .oneWayEntrances = {
+            ENTRANCE(ZORA_CAPE, 6), // From Song of Soaring
+            ENTRANCE(ZORA_CAPE, 9), // From Great Bay Temple Blue Warp
+        }
     };
     Regions[RR_ZORA_CAPE_GROTTO] = RandoRegion{ .name = "Zora Cape Grotto", .sceneId = SCENE_KAKUSIANA,
         .checks = {
@@ -177,11 +181,7 @@ static RegisterShipInitFunc initFunc([]() {
         .connections = {
             CONNECTION(RR_ZORA_CAPE_BEFORE_GREAT_BAY_TEMPLE, CAN_BE_ZORA),
             CONNECTION(RR_ZORA_CAPE_GROTTO, CAN_USE_EXPLOSIVE || CAN_BE_GORON), // TODO: Grotto mapping
-        },
-        .oneWayEntrances = {
-            ENTRANCE(ZORA_CAPE, 6), // From Song of Soaring
-            ENTRANCE(ZORA_CAPE, 9), // From Great Bay Temple Blue Warp
-        },
+        }
     };
     Regions[RR_ZORA_HALL_EVANS_ROOM] = RandoRegion{ .name = "Evan's Room", .sceneId = SCENE_BANDROOM,
         .checks = {


### PR DESCRIPTION
Moved the owl warp & dungeon warp drop off from RR_ZORA_CAPE to RR_ZORA_CAPE_BEFORE_GREAT_BAY_TEMPLE, this resolved some logic issues where the pots next to the owl statue was not considered in logic if you lacked the Zora Mask but had Zora Cape Owl Warp and Soaring(As the logic assumes you were on the coast as opposed to near Zora Hall.)

I know that region got removed and readded at some point so it prob just got missed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2580425526.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2580445179.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2580450551.zip)
<!--- section:artifacts:end -->