### PR TITLE
Seemingly fixed starting items on Linux

### DIFF
--- a/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -95,7 +95,7 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                         optionId = RO_STARTING_ITEMS_3;
                     }
                     uint32_t startingItemsBits = RANDO_SAVE_OPTIONS[optionId];
-                    if ((startingItemsBits & (1 << i % 32)) != 0) {
+                    if ((startingItemsBits & (1 << (i % 32))) != 0) {
                         startingItems.push_back(itemId);
                     }
                 }

--- a/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -95,7 +95,7 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                         optionId = RO_STARTING_ITEMS_3;
                     }
                     uint32_t startingItemsBits = RANDO_SAVE_OPTIONS[optionId];
-                    if ((startingItemsBits & (1 << i)) != 0) {
+                    if ((startingItemsBits & (1 << i % 32)) != 0) {
                         startingItems.push_back(itemId);
                     }
                 }

--- a/mm/2s2h/Rando/Spoiler/Apply.cpp
+++ b/mm/2s2h/Rando/Spoiler/Apply.cpp
@@ -37,7 +37,7 @@ void ApplyToSaveContext(nlohmann::json spoiler) {
             optionId = RO_STARTING_ITEMS_3;
         }
         uint32_t startingItemsBits = RANDO_SAVE_OPTIONS[optionId];
-        if ((startingItemsBits & (1 << i)) != 0) {
+        if ((startingItemsBits & (1 << i % 32)) != 0) {
             startingItems.push_back(itemId);
         }
     }

--- a/mm/2s2h/Rando/Spoiler/Apply.cpp
+++ b/mm/2s2h/Rando/Spoiler/Apply.cpp
@@ -37,7 +37,7 @@ void ApplyToSaveContext(nlohmann::json spoiler) {
             optionId = RO_STARTING_ITEMS_3;
         }
         uint32_t startingItemsBits = RANDO_SAVE_OPTIONS[optionId];
-        if ((startingItemsBits & (1 << i % 32)) != 0) {
+        if ((startingItemsBits & (1 << (i % 32))) != 0) {
             startingItems.push_back(itemId);
         }
     }


### PR DESCRIPTION
Would def feel a lot better about this if it was tested on other platforms before getting merged, but testing it locally on Linux seems to work for me.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2581598233.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2581628326.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2581772226.zip)
<!--- section:artifacts:end -->