### PR TITLE
Execute saveLoad hook for non-fileselect loads and reset shipSaveInfo

### DIFF
--- a/mm/2s2h/DeveloperTools/WarpPoint.cpp
+++ b/mm/2s2h/DeveloperTools/WarpPoint.cpp
@@ -39,15 +39,18 @@ void Warp() {
         // to leave it as a hidden cvar. This is incompatible with the SkipToFileSelect enhancement. To enable it open
         // the Console and type: `set gDeveloperTools.WarpPoint.BootToWarpPoint 1`
         gSaveContext.gameMode = GAMEMODE_NORMAL;
-        Sram_InitNewSave();
+        Sram_InitDebugSave();
         gSaveContext.sceneLayer = 0;
         gSaveContext.save.time = CLOCK_TIME(8, 0);
         gSaveContext.save.day = 1;
         gSaveContext.save.cutsceneIndex = 0;
         gSaveContext.save.playerForm = PLAYER_FORM_HUMAN;
         gSaveContext.save.linkAge = 0;
+        // Using dummy file num to bypass debug save setup in map select and manually execute save init/load hooks after
+        gSaveContext.fileNum = 0xFE;
+        MapSelect_LoadGame((MapSelectState*)gGameState, entrance, 0);
+        // Then back to debug file num
         gSaveContext.fileNum = 0xFF;
-        MapSelect_LoadGame((MapSelectState*)gGameState, CVarGetInteger(WARP_POINT_CVAR "Entrance", 0), 0);
         // These two lines allow randomizer to be used with BootToWarpPoint. Not sure how reliable this is, might remove
         GameInteractor_ExecuteOnSaveInit(gSaveContext.fileNum);
         GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -1010,9 +1010,9 @@ void Sram_InitNewSave(void) {
 
     // #region 2S2H
     memcpy(&gSaveContext.save.shipSaveInfo.dpadEquips, &sSaveDefaultDpadItemEquips, sizeof(DpadSaveInfo));
-    gSaveContext.save.shipSaveInfo.pauseSaveEntrance = -1;
     memcpy(&gSaveContext.save.shipSaveInfo.commitHash, &gGitCommitHash,
            sizeof(gSaveContext.save.shipSaveInfo.commitHash));
+    gSaveContext.save.shipSaveInfo.pauseSaveEntrance = -1;
     gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
     gSaveContext.save.shipSaveInfo.fileCreatedAt = 0;
     //  #endregion
@@ -1239,8 +1239,11 @@ void Sram_InitDebugSave(void) {
 
     // #region 2S2H
     memcpy(&gSaveContext.save.shipSaveInfo.dpadEquips, &sSaveDefaultDpadItemEquips, sizeof(DpadSaveInfo));
+    memcpy(&gSaveContext.save.shipSaveInfo.commitHash, &gGitCommitHash,
+           sizeof(gSaveContext.save.shipSaveInfo.commitHash));
     gSaveContext.save.shipSaveInfo.pauseSaveEntrance = -1;
     gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
+    gSaveContext.save.shipSaveInfo.fileCreatedAt = 0;
     // #endregion
 
     Sram_GenerateRandomSaveFields();

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -741,6 +741,8 @@ void Sram_ResetSave(void) {
     gSaveContext.save.isOwlSave = false;
 
     memset(&gSaveContext.save.saveInfo, 0, sizeof(SaveInfo));
+    // 2S2H
+    memset(&gSaveContext.save.shipSaveInfo, 0, sizeof(ShipSaveInfo));
 }
 
 /**

--- a/mm/src/overlays/gamestates/ovl_opening/z_opening.c
+++ b/mm/src/overlays/gamestates/ovl_opening/z_opening.c
@@ -11,6 +11,8 @@
 #include "z64view.h"
 #include "regs.h"
 
+#include "2s2h/GameInteractor/GameInteractor.h"
+
 void TitleSetup_SetupTitleScreen(TitleSetupState* this) {
     static s32 sOpeningEntrances[] = { ENTRANCE(CUTSCENE, 0), ENTRANCE(CUTSCENE, 1) };
     static s32 sOpeningCutscenes[] = { 0xFFFA, 0xFFFA };
@@ -26,6 +28,8 @@ void TitleSetup_SetupTitleScreen(TitleSetupState* this) {
 
     gSaveContext.save.time = CLOCK_TIME(8, 0);
     gSaveContext.save.day = 1;
+
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
 
     STOP_GAMESTATE(&this->state);
     SET_NEXT_GAMESTATE(&this->state, Play_Init, sizeof(PlayState));

--- a/mm/src/overlays/gamestates/ovl_select/z_select.c
+++ b/mm/src/overlays/gamestates/ovl_select/z_select.c
@@ -9,8 +9,10 @@
 #include "z64view.h"
 #include "libc/alloca.h"
 #include "overlays/gamestates/ovl_title/z_title.h"
+
 #include <libultraship/bridge.h>
 #include "2s2h/DeveloperTools/BetterMapSelect.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
 
 void MapSelect_LoadConsoleLogo(MapSelectState* this) {
     STOP_GAMESTATE(&this->state);
@@ -34,6 +36,8 @@ void MapSelect_LoadGame(MapSelectState* this, u32 entrance, s32 spawn) {
             gSaveContext.cycleSceneFlags[i].clearedRoom = gSaveContext.save.saveInfo.permanentSceneFlags[i].clearedRoom;
             gSaveContext.cycleSceneFlags[i].collectible = gSaveContext.save.saveInfo.permanentSceneFlags[i].collectible;
         }
+
+        GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
         // #endregion
     }
 


### PR DESCRIPTION
This executes the `OnSaveLoad` hook in two new places, when the opening cutscene plays, and when using L+R+Z outside a real save file. This ensures that rando code is unregistered. Previously if you loaded a rando save and then console reset, all the rando stuff displays in the opening cutscene and if using L+R+Z debug file (heart piece replaced, etc).

Additionally, added a memset for shipSaveInfo struct in Sram_ResetSave so that nothing lingers when initing a save.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2620589433.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2620603049.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2620632441.zip)
<!--- section:artifacts:end -->