### PR TITLE
Adjust custom item fall behavior for beehive and rupee crow

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnItem00.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnItem00.cpp
@@ -61,13 +61,19 @@ void Rando::ActorBehavior::InitEnItem00Behavior() {
         // Prevent the original item from spawning
         *should = false;
 
+        s16 itemParams = CustomItem::KILL_ON_TOUCH;
+        // Freestanding PoH & HC cannot be picked up by boomerangs
+        if (randoStaticCheck.randoCheckType == RCTYPE_FREESTANDING) {
+            itemParams |= CustomItem::ABLE_TO_ZORA_RANG;
+        }
+        // The heart piece in the bio baba grotto beehive needs to be tossed to fall to the ground
+        if (randoStaticCheck.randoCheckId == RC_TERMINA_FIELD_BIO_BABA_GROTTO) {
+            itemParams |= CustomItem::TOSS_ON_SPAWN;
+        }
+
         // If it hasn't been collected yet, spawn a dummy item
         CustomItem::Spawn(
-            actor->world.pos.x, actor->world.pos.y, actor->world.pos.z, 0,
-            // Freestanding PoH & HC cannot be picked up by boomerangs
-            CustomItem::KILL_ON_TOUCH |
-                (randoStaticCheck.randoCheckType == RCTYPE_FREESTANDING ? CustomItem::ABLE_TO_ZORA_RANG : 0),
-            randoStaticCheck.randoCheckId,
+            actor->world.pos.x, actor->world.pos.y, actor->world.pos.z, 0, itemParams, randoStaticCheck.randoCheckId,
             [](Actor* actor, PlayState* play) {
                 auto& randoStaticCheck = Rando::StaticData::Checks[(RandoCheckId)CUSTOM_ITEM_PARAM];
                 switch (randoStaticCheck.flagType) {

--- a/mm/2s2h/Rando/ActorBehavior/EnRuppecrow.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnRuppecrow.cpp
@@ -28,6 +28,10 @@ void Rando::ActorBehavior::InitEnRuppecrowBehavior() {
                 Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
             });
 
+        // Apply rupee drop heavy gravity
+        rupee->actor.gravity = -5.0f;
+        rupee->actor.velocity.y = 0.0f;
+
         Actor_PlaySfx(&refActor->actor, NA_SE_EV_RUPY_FALL);
 
         *should = false;


### PR DESCRIPTION
This adjusts the custom item velocity and gravity for the termina guay rupee drops so that they match more with vanilla behavior. Technically the vanilla drops also bounce off the ground, but that would take more effort to implement for custom items that I didn't want in this scope.

Also applies the `TOSS_ON_SPAWN` flag for the bio baba beehive drop to match vanilla behavior so that the item can fall down if the beehive is broken with something other than an arrow (hookshot, bombs, zora fin, etc). Since the location where the item00 init is hooked is the same as freestanding and other heart pieces, I needed to make an explicit check the `RC_` value for bio baba. I'm not happy with that, but I think this is the only instance that will ever need to be accounted for this way.

In the future if beehive checks are ever added, I think this will still need to remain as is due to the differences between `RCTYPE_HEART` and `RCTYPE_BEEHIVE`, and the heart piece always being shuffled.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2595023498.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2595037047.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2595090691.zip)
<!--- section:artifacts:end -->