### PR TITLE
Changeover Digit Textures

### DIFF
--- a/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
+++ b/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
@@ -39,7 +39,7 @@ void DrawInGameTimer(uint32_t timer) {
             textureIndex = textToDecode[i] - '0';
         }
         if (textToDecode[i] == '.') {
-            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 8.0f);
+            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (8.0f * windowScale));
             ImGui::Image(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(digitList[textureIndex]),
                          ImVec2(8.0f * windowScale, 8.0f * windowScale), ImVec2(0, 0.5f), ImVec2(1, 1));
         } else {
@@ -74,10 +74,7 @@ void DisplayOverlayWindow::Draw() {
     ImGui::Image(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gTimerClockIconTex),
                  ImVec2(16.0f * windowScale, 16.0f * windowScale));
     ImGui::SameLine(0, 10.0f);
-    // DrawInGameTimer(TOTAL_GAMEPLAY_TIME); // TODO: Once LUS is bumped to include the Texture Alpha changes, this can
-    // take over.
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() - (2.0f * windowScale));
-    ImGui::Text(formatTimeDisplay(TOTAL_GAMEPLAY_TIME).c_str());
+    DrawInGameTimer(TOTAL_GAMEPLAY_TIME);
 
     ImGui::End();
 


### PR DESCRIPTION
Converts the Digit Textures to their in game counterparts now that LUS is updated.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2597626627.zip)
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2597628715.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2597633261.zip)
<!--- section:artifacts:end -->