### PR TITLE
Adjusted Song GI colors to be more distinguishable

### DIFF
--- a/mm/2s2h/Rando/DrawItem.cpp
+++ b/mm/2s2h/Rando/DrawItem.cpp
@@ -92,7 +92,7 @@ void DrawSong(RandoItemId randoItemId) {
             gDPSetEnvColor(POLY_XLU_DISP++, 98, 177, 211, 255);
             break;
         case RI_SONG_HEALING:
-            gDPSetEnvColor(POLY_XLU_DISP++, 255, 192, 203, 255);
+            gDPSetEnvColor(POLY_XLU_DISP++, 255, 150, 230, 255);
             break;
         case RI_SONG_STORMS:
             gDPSetEnvColor(POLY_XLU_DISP++, 146, 146, 146, 255);
@@ -101,16 +101,16 @@ void DrawSong(RandoItemId randoItemId) {
             gDPSetEnvColor(POLY_XLU_DISP++, 98, 255, 98, 255);
             break;
         case RI_SONG_SOARING:
-            gDPSetEnvColor(POLY_XLU_DISP++, 255, 177, 177, 255);
+            gDPSetEnvColor(POLY_XLU_DISP++, 200, 160, 255, 255);
             break;
         case RI_SONG_ELEGY:
             gDPSetEnvColor(POLY_XLU_DISP++, 255, 98, 0, 255);
             break;
         case RI_SONG_LULLABY_INTRO:
-            gDPSetEnvColor(POLY_XLU_DISP++, 255, 194, 194, 255);
+            gDPSetEnvColor(POLY_XLU_DISP++, 255, 100, 100, 255);
             break;
         case RI_SONG_LULLABY:
-            gDPSetEnvColor(POLY_XLU_DISP++, 255, 100, 100, 255);
+            gDPSetEnvColor(POLY_XLU_DISP++, 255, 20, 20, 255);
             break;
         case RI_SONG_OATH:
             gDPSetEnvColor(POLY_XLU_DISP++, 98, 0, 98, 255);


### PR DESCRIPTION
Songs changed in this PR are, 
Healing: Changed to light pink
Soaring: Changed to lavender 
Goron's Lullaby: More red than before
Lullaby Intro: Same as full Lullaby but more faded red

All other songs are the same as before. They are still hard to tell apart in shops, due to the shiny front facing surface.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2601074070.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2601087503.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2605750087.zip)
<!--- section:artifacts:end -->