### PR TITLE
Removed CAN_BE_GORON from RR_IKANA_GRAVEYARD_GROTTO access.

### DIFF
--- a/mm/2s2h/Rando/Logic/Regions/East.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/East.cpp
@@ -180,7 +180,7 @@ static RegisterShipInitFunc initFunc([]() {
         },
         .connections = {
             CONNECTION(RR_IKANA_GRAVEYARD_UPPER, CAN_PLAY_SONG(SONATA)),
-            CONNECTION(RR_IKANA_GRAVEYARD_GROTTO, CAN_USE_EXPLOSIVE || CAN_BE_GORON), // TODO: Grotto mapping
+            CONNECTION(RR_IKANA_GRAVEYARD_GROTTO, CAN_USE_EXPLOSIVE), // TODO: Grotto mapping
         },
         .oneWayEntrances = {
             ENTRANCE(IKANA_GRAVEYARD, 4), // Exiting Dampe's house


### PR DESCRIPTION
Goron cannot open this grotto.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2612003112.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2612024253.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2612082570.zip)
<!--- section:artifacts:end -->