### PR TITLE
Refactor Goron Lullaby Skip

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
@@ -9,6 +9,8 @@ extern "C" {
 #include "variables.h"
 #include "overlays/actors/ovl_En_Gk/z_en_gk.h"
 #include "functions.h"
+
+void func_80B5227C(EnGk* enGkActor, PlayState* play);
 }
 
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
@@ -27,9 +29,17 @@ void RegisterSkipLearningGoronLullaby() {
 
         EnGk* enGk = (EnGk*)actor;
 
-        // Reset cutscene flags state
+        // Reset baby Goron cutscene flags state
         enGk->unk_1E4 &= ~0x20;
         *should = false;
+
+        // Set action func which puts Baby to sleep, sets calm week event flag
+        enGk->csAnimIndex = 1;  // ENGK_ANIM_1
+        enGk->animIndex = 1;  // ENGK_ANIM_1
+        enGk->actionFunc = func_80B5227C;
+
+        // Activate torches
+        Flags_SetSwitch(gPlayState, ENGK_GET_SWITCH_FLAG(&enGk->actor));
 
         if (IS_RANDO) {
             SET_WEEKEVENTREG(WEEKEVENTREG_24_80); // Ensure Goron Elder check is available

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
@@ -1,0 +1,60 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/CustomItem/CustomItem.h"
+#include "2s2h/Rando/Rando.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+#include "overlays/actors/ovl_En_Gk/z_en_gk.h"
+#include "functions.h"
+}
+
+#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+// This is a song tutorial, so the skip is forced on in rando for now
+void RegisterSkipLearningGoronLullaby() {
+    // Played Lullaby Intro for Baby Goron
+    COND_VB_SHOULD(VB_START_CUTSCENE, CVAR || IS_RANDO, {
+        s16* csId = va_arg(args, s16*);
+        Actor* actor = va_arg(args, Actor*);
+
+        if (*csId != 9 || actor == NULL || actor->id != ACTOR_EN_GK) {
+            return;
+        }
+
+        EnGk* enGk = (EnGk*)actor;
+
+        // Reset cutscene flags state
+        enGk->unk_1E4 &= ~0x20;
+        *should = false;
+
+        if (IS_RANDO) {
+            SET_WEEKEVENTREG(WEEKEVENTREG_24_80); // Ensure Goron Elder check is available
+            RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].eligible = true;
+        } else {
+            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
+                .giveItem =
+                    [](Actor* actor, PlayState* play) {
+                        if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                            CustomMessage::SetActiveCustomMessage("You learned the complete Goron Lullaby!",
+                                                                  { .textboxType = 2 });
+                        } else {
+                            CustomMessage::StartTextbox("You learned the complete Goron Lullaby!\x1C\x02\x10",
+                                                        { .textboxType = 2 });
+                        }
+                        Item_Give(gPlayState, ITEM_SONG_LULLABY);
+                    },
+                .drawItem =
+                    [](Actor* actor, PlayState* play) {
+                        Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                        Rando::DrawItem(RI_SONG_LULLABY);
+                    } });
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSkipLearningGoronLullaby, { CVAR_NAME, "IS_RANDO" });

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
@@ -8,13 +8,17 @@
 extern "C" {
 #include "variables.h"
 #include "overlays/actors/ovl_En_Gk/z_en_gk.h"
+#include "overlays/actors/ovl_En_Go/z_en_go.h"
 #include "functions.h"
 
 void func_80B5227C(EnGk* enGkActor, PlayState* play);
+void EnGo_Sleep(EnGo* enGoActor, PlayState* play);
 }
 
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+static bool isGoronSleepQueued = false;
 
 // This is a song tutorial, so the skip is forced on in rando for now
 void RegisterSkipLearningGoronLullaby() {
@@ -41,6 +45,8 @@ void RegisterSkipLearningGoronLullaby() {
         // Activate torches
         Flags_SetSwitch(gPlayState, ENGK_GET_SWITCH_FLAG(&enGk->actor));
 
+        isGoronSleepQueued = true;
+
         if (IS_RANDO) {
             SET_WEEKEVENTREG(WEEKEVENTREG_24_80); // Ensure Goron Elder check is available
             RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].eligible = true;
@@ -63,6 +69,27 @@ void RegisterSkipLearningGoronLullaby() {
                         Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
                         Rando::DrawItem(RI_SONG_LULLABY);
                     } });
+        }
+    });
+
+    COND_ID_HOOK(OnActorUpdate, ACTOR_EN_GO, CVAR || IS_RANDO, [](Actor* actor) {
+        EnGo* enGo = (EnGo*)actor;
+
+        // Should only apply this to the Goron next to the Elder's Son
+        // immediately after playing the Lullaby Intro.
+        if (ENGO_GET_TYPE(&enGo->actor) != ENGO_ASIDE_ELDERSSON) {
+            return;
+        }
+
+        // The Gorons use a very specific condition to check if they should be put to sleep.
+        // It's easier to avoid side effects by directly changing their state such that they should start
+        // to go to sleep.
+        if (isGoronSleepQueued) {
+            isGoronSleepQueued = false;
+
+            SubS_SetOfferMode(&enGo->actionFlags, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
+            enGo->sleepState = 1; // ENGO_ASLEEP_POS
+            enGo->actionFunc = EnGo_Sleep;
         }
     });
 }

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
@@ -47,10 +47,7 @@ void RegisterSkipLearningGoronLullaby() {
 
         isGoronSleepQueued = true;
 
-        if (IS_RANDO) {
-            SET_WEEKEVENTREG(WEEKEVENTREG_24_80); // Ensure Goron Elder check is available
-            RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].eligible = true;
-        } else {
+        if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GK_LULLABY, !CHECK_QUEST_ITEM(QUEST_SONG_LULLABY))) {
             GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
                 .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                 .giveItem =

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
@@ -38,8 +38,8 @@ void RegisterSkipLearningGoronLullaby() {
         *should = false;
 
         // Set action func which puts Baby to sleep, sets calm week event flag
-        enGk->csAnimIndex = 1;  // ENGK_ANIM_1
-        enGk->animIndex = 1;  // ENGK_ANIM_1
+        enGk->csAnimIndex = 1; // ENGK_ANIM_1
+        enGk->animIndex = 1;   // ENGK_ANIM_1
         enGk->actionFunc = func_80B5227C;
 
         // Activate torches

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -226,6 +226,7 @@ typedef enum {
     VB_OPEN_SNOWHEAD_FROM_SONG,
     VB_GOHT_UNFREEZE,
     VB_PERFORM_AC_COLLISION,
+    VB_GIVE_ITEM_FROM_GK_LULLABY,
 } GIVanillaBehavior;
 
 typedef enum {

--- a/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
@@ -30,6 +30,23 @@ void Rando::ActorBehavior::InitEnGKBehavior() {
         }
     });
 
+    COND_VB_SHOULD(VB_GIVE_ITEM_FROM_GK_LULLABY, IS_RANDO, {
+        // Override vanilla cutscene skip item grant behavior to use rando queue instead
+        *should = false;
+    });
+
+    COND_VB_SHOULD(VB_START_CUTSCENE, IS_RANDO, {
+        s16* csId = va_arg(args, s16*);
+        Actor* actor = va_arg(args, Actor*);
+
+        if (*csId != 9 || actor == NULL || actor->id != ACTOR_EN_GK) {
+            return;
+        }
+
+        SET_WEEKEVENTREG(WEEKEVENTREG_24_80); // Ensure Goron Elder check is available
+        RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].eligible = true;
+    });
+
     // Played Full Lullaby for Baby Goron
     COND_HOOK(OnSceneFlagSet, IS_RANDO, [](s16 sceneId, FlagType flagType, u32 flag) {
         if (sceneId == SCENE_16GORON_HOUSE && flagType == FLAG_CYCL_SCENE_SWITCH && flag == 20) {

--- a/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
@@ -43,8 +43,12 @@ void Rando::ActorBehavior::InitEnGKBehavior() {
             return;
         }
 
+        *should = false;
+
         SET_WEEKEVENTREG(WEEKEVENTREG_24_80); // Ensure Goron Elder check is available
-        RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].eligible = true;
+        if (!RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].obtained) {
+            RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].eligible = true;
+        }
     });
 
     // Played Full Lullaby for Baby Goron

--- a/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
@@ -30,23 +30,6 @@ void Rando::ActorBehavior::InitEnGKBehavior() {
         }
     });
 
-    // Played Lullaby Intro for Baby Goron
-    COND_VB_SHOULD(VB_START_CUTSCENE, IS_RANDO, {
-        s16* csId = va_arg(args, s16*);
-        Actor* actor = va_arg(args, Actor*);
-
-        if (*csId != 9 || actor == NULL || actor->id != ACTOR_EN_GK) {
-            return;
-        }
-
-        EnGk* enGk = (EnGk*)actor;
-
-        enGk->unk_1E4 &= ~0x20;
-        *should = false;
-        SET_WEEKEVENTREG(WEEKEVENTREG_24_80); // Ensure Goron Elder check is available
-        RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].eligible = true;
-    });
-
     // Played Full Lullaby for Baby Goron
     COND_HOOK(OnSceneFlagSet, IS_RANDO, [](s16 sceneId, FlagType flagType, u32 flag) {
         if (sceneId == SCENE_16GORON_HOUSE && flagType == FLAG_CYCL_SCENE_SWITCH && flag == 20) {


### PR DESCRIPTION
Moves Learning Lullaby Cutscene skip to be more like Song of Storms cutscene skip to allow it to work in both vanilla and rando save files.

Currently only works in rando.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2633587994.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2633603676.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2633698324.zip)
<!--- section:artifacts:end -->