### PR TITLE
Restrict Milk bar check logic to Mr. Barten actor

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnTab.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnTab.cpp
@@ -84,6 +84,11 @@ void Rando::ActorBehavior::InitEnTabBehavior() {
     COND_VB_SHOULD(VB_EXEC_MSG_EVENT, IS_RANDO && RANDO_SAVE_OPTIONS[RO_SHUFFLE_SHOPS], {
         u32 cmdId = va_arg(args, u32);
         Actor* actor = va_arg(args, Actor*);
+
+        if (actor->id != ACTOR_EN_TAB) { // Mr. Barten
+            return;
+        }
+
         MsgScript* script = va_arg(args, MsgScript*);
         MsgEventCallback* callback = va_arg(args, MsgEventCallback*);
 


### PR DESCRIPTION
The Milk Bar check hook applied to any scripted actor, which resulted in the Swamp Tourism Center NPC thinking the player never had a picture to show (and probably other issues not yet discovered).

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2618535380.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2618587468.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2618840956.zip)
<!--- section:artifacts:end -->