### PR TITLE
Cutscene Skip: Biggoron Snowhead Cutscene

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBiggoronSnowheadLullaby.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBiggoronSnowheadLullaby.cpp
@@ -17,7 +17,8 @@ void RegisterSkipBiggoronSnowheadLullabyCutscene() {
         s16* csId = va_arg(args, s16*);
         Actor* actor = va_arg(args, Actor*);
 
-        if (*csId != BIGGORON_GORON_LULLABY_CSID || actor == NULL || actor->id != ACTOR_EN_DAI || gPlayState->sceneId != SCENE_12HAKUGINMAE) {
+        if (*csId != BIGGORON_GORON_LULLABY_CSID || actor == NULL || actor->id != ACTOR_EN_DAI ||
+            gPlayState->sceneId != SCENE_12HAKUGINMAE) {
             return;
         }
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBiggoronSnowheadLullaby.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBiggoronSnowheadLullaby.cpp
@@ -1,0 +1,40 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+#include "functions.h"
+}
+
+#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+#define BIGGORON_GORON_LULLABY_CSID 11
+
+void RegisterSkipBiggoronSnowheadLullabyCutscene() {
+    COND_VB_SHOULD(VB_START_CUTSCENE, CVAR, {
+        s16* csId = va_arg(args, s16*);
+        Actor* actor = va_arg(args, Actor*);
+
+        if (*csId != BIGGORON_GORON_LULLABY_CSID || actor == NULL || actor->id != ACTOR_EN_DAI || gPlayState->sceneId != SCENE_12HAKUGINMAE) {
+            return;
+        }
+
+        *should = false;
+
+        // This register gets set at the end of the cutscene after Biggoron falls off of the
+        // Snowhead Temple path. The actor can be killed since he doesn't do anything, and
+        // in fact the actor is automatically killed when the scene is reloaded if this is set.
+        SET_WEEKEVENTREG(WEEKEVENTREG_30_01);
+
+        // Make the cutscene skip less jarring by playing the SFX that
+        // plays at the end of the cutscene so that the player knows
+        // the cutscene was skipped.
+        Audio_PlaySfx(NA_SE_EV_ROLL_AND_FALL);
+        Audio_PlaySequenceInCutscene(NA_BGM_DUNGEON_APPEAR);
+        Actor_Kill(actor);
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSkipBiggoronSnowheadLullabyCutscene, { CVAR_NAME });

--- a/mm/2s2h/Rando/ActorBehavior/EnDai.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnDai.cpp
@@ -5,7 +5,7 @@ extern "C" {
 #include "overlays/actors/ovl_En_Dai/z_en_dai.h"
 }
 
-// This handles opening great bay temple without needing the New Wave Bossa Nova
+// This handles opening Snowhead Temple without needing the Goron Lullaby
 void Rando::ActorBehavior::InitEnDaiBehavior() {
     bool shouldRegister = IS_RANDO && RANDO_SAVE_OPTIONS[RO_ACCESS_DUNGEONS] == RO_ACCESS_DUNGEONS_FORM_ONLY;
 


### PR DESCRIPTION
Skips playing the cutscene and kills the actor, while setting appropriate flags to ensure vanilla behavior is preserved.

Plays the Dungeon Appears BGM fanfare to maximize feedback to the player that the cutscene skip was successful and occurred.

Footage of implementation behavior here (courtesy of Tristnal in the Discord): 
https://youtu.be/ktsbYyYieoE?si=N9CtFlCJmIAGHocE&t=215

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2621297644.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2621307781.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2621329249.zip)
<!--- section:artifacts:end -->