### PR TITLE
Item Tracker: Gold Skulltulas

### DIFF
--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
@@ -377,28 +377,26 @@ ItemTrackerWindow::CountInfo ItemTrackerWindow::GetItemCountInfo(int itemId) {
                 .maxCap = 15,
             };
             break;
-        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP:
-            {
-                u32 swampTokenCount = (gSaveContext.save.saveInfo.skullTokenCount >> 16) & 0xFFFF;
-            
-                info = {
-                    .cur = (uint16_t) swampTokenCount,
-                    .curCap = 30,
-                    .maxCap = 30,
-                };
-                break;
-            }
-        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_OCEAN:
-            {
-                u32 oceanTokenCount = gSaveContext.save.saveInfo.skullTokenCount & 0xFFFF;
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP: {
+            u32 swampTokenCount = (gSaveContext.save.saveInfo.skullTokenCount >> 16) & 0xFFFF;
 
-                info = {
-                    .cur = (uint16_t) oceanTokenCount,
-                    .curCap = 30,
-                    .maxCap = 30,
-                };
-                break;
-            }
+            info = {
+                .cur = (uint16_t)swampTokenCount,
+                .curCap = 30,
+                .maxCap = 30,
+            };
+            break;
+        }
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_OCEAN: {
+            u32 oceanTokenCount = gSaveContext.save.saveInfo.skullTokenCount & 0xFFFF;
+
+            info = {
+                .cur = (uint16_t)oceanTokenCount,
+                .curCap = 30,
+                .maxCap = 30,
+            };
+            break;
+        }
         case TRACKER_ITEM_KEY_WOODFALL:
         case TRACKER_ITEM_KEY_SNOWHEAD:
         case TRACKER_ITEM_KEY_GREAT_BAY:
@@ -647,8 +645,7 @@ int ItemTrackerWindow::DrawGoldSkulltulas(int columns, int prevDrawnColumns) {
         ImGui::SetCursorPos(pos);
         ImGui::BeginGroup();
 
-        DrawItem((char*)sGoldSkulltulaTextures[i], i == 0 ? swampTokenCount == 0: oceanTokenCount == 0,
-                    mIconSize);
+        DrawItem((char*)sGoldSkulltulaTextures[i], i == 0 ? swampTokenCount == 0 : oceanTokenCount == 0, mIconSize);
         DrawItemCount(i + TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP, pos);
 
         ImGui::EndGroup();

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
@@ -23,6 +23,8 @@ typedef enum {
     TRACKER_ITEM_STRAY_FAIRY_SNOWHEAD,
     TRACKER_ITEM_STRAY_FAIRY_GREAT_BAY,
     TRACKER_ITEM_STRAY_FAIRY_STONE_TOWER,
+    TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP,
+    TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_OCEAN,
     TRACKER_ITEM_KEY_WOODFALL,
     TRACKER_ITEM_KEY_SNOWHEAD,
     TRACKER_ITEM_KEY_GREAT_BAY,
@@ -55,6 +57,7 @@ ItemTrackerWindow::~ItemTrackerWindow() {
     config->SetInteger(CFG_TRACKER_ITEM("MiscDrawMode"), (int8_t)mItemDrawModes[SECTION_MISC]);
     config->SetInteger(CFG_TRACKER_ITEM("SongsDrawMode"), (int8_t)mItemDrawModes[SECTION_SONGS]);
     config->SetInteger(CFG_TRACKER_ITEM("StrayFairiesDrawMode"), (int8_t)mItemDrawModes[SECTION_STRAY_FAIRIES]);
+    config->SetInteger(CFG_TRACKER_ITEM("GoldSkulltulasDrawMode"), (int8_t)mItemDrawModes[SECTION_GOLD_SKULLTULAS]);
     config->SetInteger(CFG_TRACKER_ITEM("DungeonDrawMode"), (int8_t)mItemDrawModes[SECTION_DUNGEON]);
 
     config->Save();
@@ -96,6 +99,8 @@ void ItemTrackerWindow::LoadSettings() {
         CFG_TRACKER_ITEM("SongsDrawMode"), (int32_t)ItemTrackerDisplayType::MainWindow);
     mItemDrawModes[SECTION_STRAY_FAIRIES] = (ItemTrackerDisplayType)config->GetInteger(
         CFG_TRACKER_ITEM("StrayFairiesDrawMode"), (int32_t)ItemTrackerDisplayType::MainWindow);
+    mItemDrawModes[SECTION_GOLD_SKULLTULAS] = (ItemTrackerDisplayType)config->GetInteger(
+        CFG_TRACKER_ITEM("GoldSkulltulasDrawMode"), (int32_t)ItemTrackerDisplayType::MainWindow);
     mItemDrawModes[SECTION_DUNGEON] = (ItemTrackerDisplayType)config->GetInteger(
         CFG_TRACKER_ITEM("DungeonDrawMode"), (int32_t)ItemTrackerDisplayType::MainWindow);
 }
@@ -232,6 +237,11 @@ static constexpr std::array<const char*, 4> sStrayFairyTextures = {
     gDungeonStrayFairyStoneTowerIconTex,
 };
 
+static constexpr std::array<const char*, 4> sGoldSkulltulaTextures = {
+    gQuestIconGoldSkulltulaTex,
+    gQuestIconGoldSkulltula2Tex,
+};
+
 static constexpr uint16_t sSmallKeyCounts[4] = { 1, 3, 1, 4 };
 
 bool ItemTrackerWindow::HasAmmoCount(int itemId) {
@@ -328,6 +338,8 @@ bool ItemTrackerWindow::HasItemCount(int itemId) {
         case TRACKER_ITEM_STRAY_FAIRY_SNOWHEAD:
         case TRACKER_ITEM_STRAY_FAIRY_GREAT_BAY:
         case TRACKER_ITEM_STRAY_FAIRY_STONE_TOWER:
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP:
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_OCEAN:
         case TRACKER_ITEM_KEY_WOODFALL:
         case TRACKER_ITEM_KEY_SNOWHEAD:
         case TRACKER_ITEM_KEY_GREAT_BAY:
@@ -365,6 +377,28 @@ ItemTrackerWindow::CountInfo ItemTrackerWindow::GetItemCountInfo(int itemId) {
                 .maxCap = 15,
             };
             break;
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP:
+            {
+                u32 swampTokenCount = (gSaveContext.save.saveInfo.skullTokenCount >> 16) & 0xFFFF;
+            
+                info = {
+                    .cur = (uint16_t) swampTokenCount,
+                    .curCap = 30,
+                    .maxCap = 30,
+                };
+                break;
+            }
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_OCEAN:
+            {
+                u32 oceanTokenCount = gSaveContext.save.saveInfo.skullTokenCount & 0xFFFF;
+
+                info = {
+                    .cur = (uint16_t) oceanTokenCount,
+                    .curCap = 30,
+                    .maxCap = 30,
+                };
+                break;
+            }
         case TRACKER_ITEM_KEY_WOODFALL:
         case TRACKER_ITEM_KEY_SNOWHEAD:
         case TRACKER_ITEM_KEY_GREAT_BAY:
@@ -597,6 +631,31 @@ int ItemTrackerWindow::DrawStrayFairies(int columns, int prevDrawnColumns) {
     return 1;
 }
 
+int ItemTrackerWindow::DrawGoldSkulltulas(int columns, int prevDrawnColumns) {
+    int topPadding = 0;
+
+    // upper 16 bits store Swamp skulls, lower 16 bits store Ocean skulls
+    u32 swampTokenCount = (gSaveContext.save.saveInfo.skullTokenCount >> 16) & 0xFFFF;
+    u32 oceanTokenCount = gSaveContext.save.saveInfo.skullTokenCount & 0xFFFF;
+
+    for (size_t i = 0; i < 2; i++) {
+        int row = prevDrawnColumns + (i / columns);
+        int column = i % columns;
+        ImVec2 pos = ImVec2((column * (mIconSize + mIconSpacing) + 8.0f),
+                            (row * (mIconSize + mIconSpacing)) + 8.0f + topPadding);
+
+        ImGui::SetCursorPos(pos);
+        ImGui::BeginGroup();
+
+        DrawItem((char*)sGoldSkulltulaTextures[i], i == 0 ? swampTokenCount == 0: oceanTokenCount == 0,
+                    mIconSize);
+        DrawItemCount(i + TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP, pos);
+
+        ImGui::EndGroup();
+    }
+    return 1;
+}
+
 int ItemTrackerWindow::DrawSongs(int columns, int prevDrawnColumns) {
     int topPadding = 0;
 
@@ -770,6 +829,20 @@ void ItemTrackerWindow::DrawItemsInRows(int columns) {
         }
         advancedBy = DrawStrayFairies(5, drawPos);
         if (mItemDrawModes[SECTION_STRAY_FAIRIES] == ItemTrackerDisplayType::Separate) {
+            EndFloatingWindows();
+        } else {
+            mainWindowPos += advancedBy;
+        }
+    }
+
+    if (mItemDrawModes[SECTION_GOLD_SKULLTULAS] != ItemTrackerDisplayType::Hidden) {
+        int drawPos = mainWindowPos;
+        if (mItemDrawModes[SECTION_GOLD_SKULLTULAS] == ItemTrackerDisplayType::Separate) {
+            drawPos = 0;
+            BeginFloatingWindows("Gold Skulltulas");
+        }
+        advancedBy = DrawGoldSkulltulas(2, drawPos);
+        if (mItemDrawModes[SECTION_GOLD_SKULLTULAS] == ItemTrackerDisplayType::Separate) {
             EndFloatingWindows();
         } else {
             mainWindowPos += advancedBy;

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.h
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.h
@@ -20,6 +20,7 @@ typedef enum {
     SECTION_MISC,
     SECTION_SONGS,
     SECTION_STRAY_FAIRIES,
+    SECTION_GOLD_SKULLTULAS,
     SECTION_DUNGEON,
     SECTION_MAX,
 } ItemTrackerSection;
@@ -76,6 +77,7 @@ class ItemTrackerWindow : public Ship::GuiWindow {
     int DrawMisc(int columns, int startAt);
     int DrawSongs(int columns, int startAt);
     int DrawStrayFairies(int columns, int startAt);
+    int DrawGoldSkulltulas(int columsn, int startAt);
     void DrawNote(size_t songIndex, bool drawFaded);
     void DrawOwlFace(bool drawFaded);
     int DrawDungeonItemsVert(int columns, int startAt);

--- a/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.cpp
@@ -70,6 +70,7 @@ void ItemTrackerSettingsWindow::DrawElement() {
     UIWidgets::Combobox("Miscellaneous", mItemTrackerWindow->GetDrawModePtr(SECTION_MISC), displayTypes);
     UIWidgets::Combobox("Songs", mItemTrackerWindow->GetDrawModePtr(SECTION_SONGS), displayTypes);
     UIWidgets::Combobox("Stray Fairies", mItemTrackerWindow->GetDrawModePtr(SECTION_STRAY_FAIRIES), displayTypes);
+    UIWidgets::Combobox("Gold Skulltulas", mItemTrackerWindow->GetDrawModePtr(SECTION_GOLD_SKULLTULAS), displayTypes);
     UIWidgets::Combobox("Dungeon Items", mItemTrackerWindow->GetDrawModePtr(SECTION_DUNGEON), displayTypes);
 
     UIWidgets::Checkbox(


### PR DESCRIPTION
Adds Gold Skulltulas to the Item Tracker as their own section, so as to allow users to separate it out for rando vs vanilla item tracker configurations.

![image](https://github.com/user-attachments/assets/bfe5e2e4-95a3-4f0e-9be0-764131520cb2)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2635692921.zip)
  - [2ship-windows.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2635697607.zip)
  - [2ship-mac.zip](https://nightly.link/garrettjoecox/2ship2harkinian/actions/artifacts/2635729705.zip)
<!--- section:artifacts:end -->